### PR TITLE
feat: add support for vcf 452 and vrealize suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Enhanced `Add-vRLISmtpConfiguration` cmdlet with a 2 second delay to ensure the API call completes.
 - Enhanced `Add-vRLIAuthenticationWSA` cmdlet with a 2 second delay to ensure the API call completes.
 - Enhanced `Add-vRLIAgentGroup` cmdlet with a 2 second delay to ensure the API call completes.
+- Enhanced `Export-WsaJsonSpec` to support VMware Cloud Foundation v4.5.2 and Workspace ONE Access v3.3.7.
+- Enhanced `Export-vROPSJsonSpec` to support VMware Cloud Foundation v4.5.2 and vRealize Operations v8.10.2.
+- Enhanced `Export-vRAJsonSpec` to support VMware Cloud Foundation v4.5.2 and vRealize Automation v8.11.2.
+- Enhanced `Export-vRLIJsonSpec` to support VMware Cloud Foundation v4.5.2 and vRealize Log Insight v8.10.2.
 - Added `Get-vRSLCMProductBinariesMapped` cmdlet to retrieves a list of mapped Product Binaries in vRealize Suite Lifecycle Manager.
 - Added `Get-vRSLCMProductBinaries` cmdlet to retrieve a list of product binaries in vRealize Suite Lifecycle Manager.
 - Added `Register-vRSLCMProductBinary` cmdlet to add a product binary to the vRealize Suite Lifecycle Manager inventory.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.6.0.1003'
+    ModuleVersion = '2.6.0.1004'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -33,7 +33,7 @@
     Description = 'PowerShell Module for VMware Validated Solutions'
     
     # Minimum version of the Windows PowerShell engine required by this module
-    PowerShellVersion = '5.1'
+    # PowerShellVersion = '5.1'
     
     # Name of the Windows PowerShell host required by this module
     # PowerShellHostName = ''

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -7346,6 +7346,7 @@ Function Export-vRLIJsonSpec {
                                             if ($vcfVersion -eq "4.4.1") { $vrliVersion = "8.6.2" }
                                             if ($vcfVersion -eq "4.5.0") { $vrliVersion = "8.8.2" }
                                             if ($vcfVersion -eq "4.5.1") { $vrliVersion = "8.10.2" }
+                                            if ($vcfVersion -eq "4.5.2") { $vrliVersion = "8.10.2" }
                                             if ($vcfVersion -eq "5.0.0") { $vrliVersion = "8.10.2" }
                                         } else {
                                             $vrliVersion = $customVersion
@@ -9305,6 +9306,7 @@ Function Export-vROPsJsonSpec {
                                                     if ($vcfVersion -eq "4.4.1") { $vropsVersion = "8.6.2"}
                                                     if ($vcfVersion -eq "4.5.0") { $vropsVersion = "8.6.3"}
                                                     if ($vcfVersion -eq "4.5.1") { $vropsVersion = "8.10.2"}
+                                                    if ($vcfVersion -eq "4.5.2") { $vropsVersion = "8.10.2"}
                                                     if ($vcfVersion -eq "5.0.0") { $vropsVersion = "8.10.2"}
                                                 } else {
                                                     $vropsVersion = $customVersion
@@ -11693,6 +11695,7 @@ Function Export-vRAJsonSpec {
                                                     if ($vcfVersion -eq "4.4.1") { $vraVersion = "8.6.2" }
                                                     if ($vcfVersion -eq "4.5.0") { $vraVersion = "8.8.2" }
                                                     if ($vcfVersion -eq "4.5.1") { $vraVersion = "8.11.2" }
+                                                    if ($vcfVersion -eq "4.5.2") { $vraVersion = "8.11.2" }
                                                     if ($vcfVersion -eq "5.0.0") { $vraVersion = "8.11.2" }
                                                 } else {
                                                     $vraVersion = $customVersion
@@ -24485,6 +24488,7 @@ Function Export-WsaJsonSpec {
                                                     if ($vcfVersion -eq "4.4.1") { $wsaVersion = "3.3.6"}
                                                     if ($vcfVersion -eq "4.5.0") { $wsaVersion = "3.3.6"}
                                                     if ($vcfVersion -eq "4.5.1") { $wsaVersion = "3.3.7"}
+                                                    if ($vcfVersion -eq "4.5.2") { $wsaVersion = "3.3.7"}
                                                     if ($vcfVersion -eq "5.0.0") { $wsaVersion = "3.3.7"}
                                                 } else {
                                                     $wsaVersion = $customVersion


### PR DESCRIPTION
### Summary

- Enhanced `Export-WsaJsonSpec` to support VMware Cloud Foundation v4.5.2 and Workspace ONE Access v3.3.7.
- Enhanced `Export-vROPSJsonSpec` to support VMware Cloud Foundation v4.5.2 and vRealize Operations v8.10.2.
- Enhanced `Export-vRAJsonSpec` to support VMware Cloud Foundation v4.5.2 and vRealize Automation v8.11.2.
- Enhanced `Export-vRLIJsonSpec` to support VMware Cloud Foundation v4.5.2 and vRealize Log Insight v8.10.2.

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

Closes #316 

### Additional Information

N/A