### PR TITLE
chore: bump powershell module versions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,10 +48,10 @@ The following table lists the required PowerShell module dependencies for this m
 
 PowerShell Module                                    | Version   | Publisher     | Reference
 -----------------------------------------------------|-----------|---------------|---------------------------------------------------------------------------
-[VMware.PowerCLI][psgallery-module-powercli]         | >= 13.0.0 | VMware, Inc.  | :fontawesome-solid-book: &nbsp; [Documentation][developer-module-powercli]
+[VMware.PowerCLI][psgallery-module-powercli]         | >= 13.1.0 | VMware, Inc.  | :fontawesome-solid-book: &nbsp; [Documentation][developer-module-powercli]
 [VMware.vSphere.SsoAdmin][psgallery-module-ssoadmin] | >= 1.3.9  | VMware, Inc.  | :fontawesome-brands-github: &nbsp; [GitHub][github-module-ssoadmin]
 [PowerVCF][psgallery-module-powervcf]                | >= 2.3.0  | VMware, Inc.  | :fontawesome-solid-book: &nbsp; [Documentation][docs-module-powervcf]
-[ImportExcel][psgallery-module-importexcel]          | >= 7.8.4  | Douglas Finke | :fontawesome-brands-github: &nbsp; [GitHub][github-module-importexcel]
+[ImportExcel][psgallery-module-importexcel]          | >= 7.8.5  | Douglas Finke | :fontawesome-brands-github: &nbsp; [GitHub][github-module-importexcel]
 
 ## Related Projects
 

--- a/docs/snippets/install-module.ps1
+++ b/docs/snippets/install-module.ps1
@@ -1,6 +1,6 @@
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-Install-Module -Name VMware.PowerCLI -MinimumVersion 13.0.0
+Install-Module -Name VMware.PowerCLI -MinimumVersion 13.1.0
 Install-Module -Name VMware.vSphere.SsoAdmin -MinimumVersion 1.3.9
 Install-Module -Name PowerVCF -MinimumVersion 2.3.0
-Install-Module -Name ImportExcel -MinimumVersion 7.8.4
-Install-Module -Name PowerValidatedSolutions -MinimumVersion 2.5.0
+Install-Module -Name ImportExcel -MinimumVersion 7.8.5
+Install-Module -Name PowerValidatedSolutions -MinimumVersion 2.6.0


### PR DESCRIPTION
### Summary

Bump PowerShell Module Versions in Documentation:
- VMware.PowerCLI from 13.0.0 to 13.1.0
- ImportExcel from 7.8.4 to 7.8.5
- PowerValidatedSolutions from 2.5.0 to 2.6.0

### Type

- [ ] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

### Test and Documentation

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

N/A

### Additional Information

N/A
