### PR TITLE
feat: add nsxt security policy and group apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 - Added `Get-NsxtRoutingConfigRedistributionRule` cmdlet to retrieve all the route redistribution rules for a logical router.
 - Added `Set-NsxtRoutingConfigRedistributionRule` cmdlet to configure the route redistribution rules for a logical router.
 - Added `Get-NsxtRoutingConfigRouteMap` cmdlet to retrieve the route map configuration for a logical router.
+- Added `Get-NsxtSecurityPolicy` cmdlet to retrieve a list of security policies from NSX.
+- Added `Remove-NsxtSecurityPolicy` cmdlet to remove a security policy from NSX.
+- Added `Get-NsxtGroup` cmdlet to retrieve a list of groups from NSX.
+- Added `Remove-NsxtGroup` cmdlet to remove a group from NSX.
 - Fixed `Install-SiteRecoveryManager` cmdlet where an extra space was added to the path of the OVF Tool which fails in PowerShell Core.
 - Fixed `Install-vSphereReplicationManager` cmdlet where an extra space was added to the path of the OVF Tool which fails in PowerShell Core.
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.6.0.1005'
+    ModuleVersion = '2.6.0.1006'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -22665,6 +22665,129 @@ Function Get-NsxtRoutingConfigRouteMap {
 }
 Export-ModuleMember -Function Get-NsxtRoutingConfigRouteMap
 
+Function Get-NsxtSecurityPolicy {
+    <#
+        .SYNOPSIS
+        Get configured security policies
+    
+        .DESCRIPTION
+        The Get-NsxtSecurityPolicy cmdlet returns a paginated list of security policies
+    
+        .EXAMPLE
+        Get-NsxtSecurityPolicy
+        This example retrieves a paginated list of all security policies
+
+        .EXAMPLE
+        Get-NsxtSecurityPolicy -id <id_name>
+        This example retrieves the specified security policy
+    #>
+
+    Param (
+        [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$id
+    )
+
+    Try {
+        if ($PsBoundParameters.ContainsKey("id")) {
+            $uri = "https://$nsxtmanager/policy/api/v1/infra/domains/default/security-policies/$id"
+            Invoke-RestMethod -Method GET -URI $uri -Headers $nsxtHeaders
+        } else {
+            $uri = "https://$nsxtmanager/policy/api/v1/infra/domains/default/security-policies/"
+            (Invoke-RestMethod -Method GET -URI $uri -Headers $nsxtHeaders).Results
+        }
+    } Catch {
+        Write-Error $_.Exception.Message
+    }
+}
+Export-ModuleMember -Function Get-NsxtSecurityPolicy
+
+Function Remove-NsxtSecurityPolicy {
+    <#
+        .SYNOPSIS
+        Remove a security policy
+    
+        .DESCRIPTION
+        The Remove-NsxtSecurityPolicy cmdlet removes a security policy
+    
+        .EXAMPLE
+        Remove-NsxtSecurityPolicy -id <id_name>
+        This example removes the specified security policy
+    #>
+
+    Param (
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$id
+    )
+
+    Try {
+        $uri = "https://$nsxtmanager/policy/api/v1/infra/domains/default/security-policies/$id"
+        Invoke-RestMethod -Method DELETE -URI $uri -Headers $nsxtHeaders
+    } Catch {
+        Write-Error $_.Exception.Message
+    }
+}
+Export-ModuleMember -Function Remove-NsxtSecurityPolicy
+
+Function Get-NsxtGroup {
+    <#
+        .SYNOPSIS
+        Get groups
+    
+        .DESCRIPTION
+        The Get-NsxtGroup cmdlet returns a paginated list of groups
+    
+        .EXAMPLE
+        Get-NsxtGroup
+        This example retrieves a paginated list of all groups
+
+        .EXAMPLE
+        Get-NsxtGroup -id <id>
+        This example retrieves the specified group
+    #>
+    
+    Param (
+        [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$id
+    )
+
+    Try {
+        if ($PsBoundParameters.ContainsKey("id")) {
+            $uri = "https://$nsxtmanager/policy/api/v1/infra/domains/default/groups/$id"
+            Invoke-RestMethod -Method GET -URI $uri -Headers $nsxtHeaders
+        } else {
+            #
+            $uri = "https://$nsxtmanager/policy/api/v1/infra/domains/default/groups/"
+            (Invoke-RestMethod -Method GET -URI $uri -Headers $nsxtHeaders).results
+        }
+    } Catch {
+        Write-Error $_.Exception.Message
+    }
+}
+Export-ModuleMember -Function Get-NsxtGroup
+
+Function Remove-NsxtGroup {
+    <#
+        .SYNOPSIS
+        Remove a group
+    
+        .DESCRIPTION
+        The Remove-NsxtGroup cmdlet removes a group
+    
+        .EXAMPLE
+        Remove-NsxtGroup -id <id_name>
+        This example removes the specified security policy
+    #>
+
+    Param (
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$id
+    )
+
+    Try {
+        $uri = "https://$nsxtmanager/policy/api/v1/infra/domains/default/groups/$id"
+        Invoke-RestMethod -Method DELETE -URI $uri -Headers $nsxtHeaders
+    } Catch {
+        Write-Error $_.Exception.Message
+    }
+}
+Export-ModuleMember -Function Remove-NsxtGroup
+
 #EndRegion  End NSX Functions                                  ######
 #####################################################################
 


### PR DESCRIPTION
### Summary

- Added `Get-NsxtSecurityPolicy` cmdlet to retrieve a list of security policies from NSX.
- Added `Remove-NsxtSecurityPolicy` cmdlet to remove a security policy from NSX.
- Added `Get-NsxtGroup` cmdlet to retrieve a list of groups from NSX.
- Added `Remove-NsxtGroup` cmdlet to remove a group from NSX.

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

#212 / #213

### Additional Information

N/A
