### PR TITLE
fix: replace wmi cmdlet usage with cim cmdlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Added a temporary fix in `Add-NamespacePermission` cmdlet until issue with `New-WMNamespacePermission` is resolved.
 - Fixed `Install-SiteRecoveryManager` cmdlet where an extra space was added to the path of the OVF Tool which fails in PowerShell Core.
 - Fixed `Install-vSphereReplicationManager` cmdlet where an extra space was added to the path of the OVF Tool which fails in PowerShell Core.
+- Fixed `Request-SignedCertificate` cmdlet to use CIM cmdlets to verify the MSCA host instead of previously used WMI cmdlets which fail in PowerShell Core.
 
 
 ## [v2.5.0](https://github.com/vmware/power-validated-solutions-for-cloud-foundation/releases/tag/v2.5.0)

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.6.0.1010'
+    ModuleVersion = '2.6.0.1011'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
### Summary

Replaced WMI cmdlet usage with CIM cmdlets. Since WMI cmdlets are not available in PowerShell Core, we needed to switch to using CIM cmdlets as they are available in both PowerShell Core and Windows PowerShell.

### Type

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

Tested certificate request and installation process for Supervisor Clusters from end to end, including New-SupervisorClusterCSR, Request-SignedCertificate, and Install-SupervisorClusterCertificate.

### Issue References

Closes #332 

### Additional Information
