### PR TITLE
feat: enhance `Add-ContentLibrary` for powershell 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enhanced `Get-LocalUserPasswordExpiration` cmdlet to allow for the use of a `-sudo` to elevate the privileges to run the command on a virtual appliance when the user is not `root`.
 - Enhanced `Set-LocalUserPasswordExpiration` cmdlet to allow for the use of a `-sudo` to elevate the privileges to run the command on a virtual appliance when the user is not `root`.
 - Enhanced `Add-ContentLibrary` cmdlet to check the VMware Cloud Foundation version when adding a subscribed content library. If the version is 5.0.0 or later and the `-subscriptionUrl` parameter is set to `wp-content.vmware.com`, a warning message is displayed and the cmdlet exits.
+- Enhanced `Add-ContentLibrary` cmdlet to work on both PowerShell 7 and Windows PowerShell 5.1.
 
 ## [v2.6.0](https://github.com/vmware/power-validated-solutions-for-cloud-foundation/releases/tag/v2.6.0)
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.7.0.1002'
+    ModuleVersion = '2.7.0.1003'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    In order to have the best experience with our community, we recommend that you read the code of conduct and contributing guidelines before submitting a pull request.
    
    By submitting this pull request, you confirm that you have read, understood, and agreed to the project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.
    For more information, please refer to https://www.conventionalcommits.org.
-->

### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->

- Enhanced `Add-ContentLibrary` cmdlet to work on both PowerShell 7 and Windows PowerShell 5.1.
- Updated `CHANGELOG.md`.
- Updated module version to 2.7.0.1003.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

Withe the `-subscriptionUrl` check commented out and run with `-Debug`:

```powershell
PS F:\> Add-ContentLibrary -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re123! -domain sfo-w01 -contentLibraryName Kubernetes1 -subscriptionUrl https://wp-content.vmware.com/v2/latest/lib.json -Debug
DEBUG: 8/30/2023 9:55:35 AM     Get-ContentLibrary
DEBUG: 8/30/2023 9:55:36 AM     Get-Datastore
DEBUG: 8/30/2023 9:55:46 AM     New-ContentLibrary      52723e4d-604b-8b82-28b3-0560363a4416
DEBUG: 8/30/2023 9:55:46 AM     New-ContentLibrary
DEBUG: 8/30/2023 9:55:46 AM     Get-ContentLibrary
Creating Content Library in vCenter Server (sfo-w01-vc01.sfo.rainpole.io) named (Kubernetes1): SUCCESSFUL
DEBUG: 8/30/2023 9:55:46 AM     Disconnect-VIServer

PS F:\> Add-ContentLibrary -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re123! -domain sfo-w01 -contentLibraryName Kubernetes1 -subscriptionUrl https://wp-content.vmware.com/v2/latest/lib.json -Debug
DEBUG: 8/30/2023 10:01:31 AM    Get-ContentLibrary
WARNING: Creating Content Library in vCenter Server (sfo-w01-vc01.sfo.rainpole.io) named (Kubernetes1), already exists: SKIPPED
DEBUG: 8/30/2023 10:01:31 AM    Disconnect-VIServer
```

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes' keyword followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Closes #001
-->

Closes #329

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
