### PR TITLE
chore: update aria product versions for json specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
   - `vrli-vcf-vmVrslcm.json` -> `aria-operations-logs-alerts-vm-asl.json`
   - `vrops-srm-notifications.csv` -> `aria-operations-notifications-srm.csv`
   - `vrops-vcf-notifications.csv` -> `aria-operations-notifications-vcf.csv`
+- Enhanced `Export-vROPSJsonSpec` to support VMware Cloud Foundation v5.1.0 and vRealize Operations v8.12.1.
+- Enhanced `Export-vRAJsonSpec` to support VMware Cloud Foundation v5.1.0 and vRealize Automation v8.13.1.
+- Enhanced `Export-vRLIJsonSpec` to support VMware Cloud Foundation v5.1.0 and vRealize Log Insight v8.12.0.
 
 ## [v2.6.0](https://github.com/vmware/power-validated-solutions-for-cloud-foundation/releases/tag/v2.6.0)
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.7.0.1009'
+    ModuleVersion = '2.7.0.1010'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -7351,16 +7351,17 @@ Function Export-vRLIJsonSpec {
                                             'properties'	= ($worker2Properties | Select-Object -Skip 0)
                                         }
 
-                                        #### Generate the Aria Operations for Logs Properties Section
+                                        #### Generate the VMware Aria Operations for Logs Properties Section
                                         if (!$PsBoundParameters.ContainsKey("customVersion")) { 
                                             if ($vcfVersion -eq "4.3.0") { $vrliVersion = "8.4.0" }
                                             if ($vcfVersion -eq "4.3.1") { $vrliVersion = "8.4.1" }
                                             if ($vcfVersion -eq "4.4.0") { $vrliVersion = "8.6.2" }
                                             if ($vcfVersion -eq "4.4.1") { $vrliVersion = "8.6.2" }
                                             if ($vcfVersion -eq "4.5.0") { $vrliVersion = "8.8.2" }
-                                            if ($vcfVersion -eq "4.5.1") { $vrliVersion = "8.10.2" }
-                                            if ($vcfVersion -eq "4.5.2") { $vrliVersion = "8.10.2" }
-                                            if ($vcfVersion -eq "5.0.0") { $vrliVersion = "8.10.2" }
+                                            if ($vcfVersion -eq "4.5.1") { $vrliVersion = "8.12.0" }
+                                            if ($vcfVersion -eq "4.5.2") { $vrliVersion = "8.12.0" }
+                                            if ($vcfVersion -eq "5.0.0") { $vrliVersion = "8.12.0" }
+                                            if ($vcfVersion -eq "5.1.0") { $vrliVersion = "8.12.0" }
                                         } else {
                                             $vrliVersion = $customVersion
                                         }
@@ -9444,9 +9445,10 @@ Function Export-vROPsJsonSpec {
                                                     if ($vcfVersion -eq "4.4.0") { $vropsVersion = "8.6.2"}
                                                     if ($vcfVersion -eq "4.4.1") { $vropsVersion = "8.6.2"}
                                                     if ($vcfVersion -eq "4.5.0") { $vropsVersion = "8.6.3"}
-                                                    if ($vcfVersion -eq "4.5.1") { $vropsVersion = "8.10.2"}
-                                                    if ($vcfVersion -eq "4.5.2") { $vropsVersion = "8.10.2"}
-                                                    if ($vcfVersion -eq "5.0.0") { $vropsVersion = "8.10.2"}
+                                                    if ($vcfVersion -eq "4.5.1") { $vropsVersion = "8.12.1"}
+                                                    if ($vcfVersion -eq "4.5.2") { $vropsVersion = "8.12.1"}
+                                                    if ($vcfVersion -eq "5.0.0") { $vropsVersion = "8.12.1"}
+                                                    if ($vcfVersion -eq "5.1.0") { $vropsVersion = "8.12.1"}
                                                 } else {
                                                     $vropsVersion = $customVersion
                                                 }
@@ -11964,9 +11966,10 @@ Function Export-vRAJsonSpec {
                                                     if ($vcfVersion -eq "4.4.0") { $vraVersion = "8.6.2" }
                                                     if ($vcfVersion -eq "4.4.1") { $vraVersion = "8.6.2" }
                                                     if ($vcfVersion -eq "4.5.0") { $vraVersion = "8.8.2" }
-                                                    if ($vcfVersion -eq "4.5.1") { $vraVersion = "8.11.2" }
-                                                    if ($vcfVersion -eq "4.5.2") { $vraVersion = "8.11.2" }
-                                                    if ($vcfVersion -eq "5.0.0") { $vraVersion = "8.11.2" }
+                                                    if ($vcfVersion -eq "4.5.1") { $vraVersion = "8.13.1" }
+                                                    if ($vcfVersion -eq "4.5.2") { $vraVersion = "8.13.1" }
+                                                    if ($vcfVersion -eq "5.0.0") { $vraVersion = "8.13.1" }
+                                                    if ($vcfVersion -eq "5.1.0") { $vraVersion = "8.13.1" }
                                                 } else {
                                                     $vraVersion = $customVersion
                                                 }


### PR DESCRIPTION
### Summary

- Enhanced `Export-vROPSJsonSpec` to support VMware Cloud Foundation v5.1.0 and vRealize Operations v8.12.1.
- Enhanced `Export-vRAJsonSpec` to support VMware Cloud Foundation v5.1.0 and vRealize Automation v8.13.1.
- Enhanced `Export-vRLIJsonSpec` to support VMware Cloud Foundation v5.1.0 and vRealize Log Insight v8.12.0.

### Type

- [ ] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [x] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

N/A

### Additional Information

N/A
