### PR TITLE
feat: enhancements for nsx and operations for logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 - Enhanced `Export-vRAJsonSpec` to support VMware Cloud Foundation v5.1.0 and vRealize Automation v8.12.2.
 - Enhanced `Export-vRLIJsonSpec` to support VMware Cloud Foundation v5.1.0 and vRealize Log Insight v8.12.0.
 - Enhanced `Export-WsaJsonSpec` to support VMware Cloud Foundation v5.1.0 and Workspace ONE Access v3.3.7.
+- Added `Get-NsxtLdap` cmdlet to retrieve LDAP identity providers from NSX Manager.
+- Added `Remove-NsxtLdap` cmdlet to remove an LDAP identity provider from NSX Manager.
+- Enhanced `Install-vRLIPhotonAgent` cmdlet to support VMware Aria Operations for Logs agent configuration.
 
 ## [v2.6.0](https://github.com/vmware/power-validated-solutions-for-cloud-foundation/releases/tag/v2.6.0)
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.7.0.1012'
+    ModuleVersion = '2.7.0.1013'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -7738,6 +7738,7 @@ Function Install-vRLIPhotonAgent {
                                                 if ($output.ScriptOutput.Contains("/lib/systemd/system/liagentd.service; enabled")) {
                                                     $configureAgent = @(
                                                         "sed -i 's/;hostname=LOGINSIGHT/hostname=$($vcfVrliDetails.fqdn)/' /var/lib/loginsight-agent/liagent.ini",
+                                                        "sed -i 's/;hostname=OPERATIONS_FOR_LOGS/hostname=$($vcfVrliDetails.fqdn)/' /var/lib/loginsight-agent/liagent.ini",
                                                         "sed -i 's/;proto=cfapi/proto=cfapi/' /var/lib/loginsight-agent/liagent.ini",
                                                         "sed -i 's/;port=9543/port=9000/' /var/lib/loginsight-agent/liagent.ini",
                                                         "sed -i 's/;ssl=yes/ssl=no/' /var/lib/loginsight-agent/liagent.ini",
@@ -19487,6 +19488,67 @@ Function Set-NsxtVidm {
 }
 Export-ModuleMember -Function Set-NsxtVidm
 
+Function Get-NsxtLdap {
+    <#
+        .SYNOPSIS
+        Get LDAP configuration
+
+        .DESCRIPTION
+        The Get-NsxtLdap cmdlet gets the LDAP configuration
+
+        .EXAMPLE
+        Get-NsxtLdap
+        This example retrives a list of all configure LDAP identiry sources
+
+        .EXAMPLE
+        Get-NsxtLdap -id sfo
+        This example retrives the details of a one LDAP identity source 
+    #>
+
+    Param (
+        [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$id
+    )
+
+    Try {
+        if ($PsBoundParameters.ContainsKey("id")) {
+            $uri = "https://$nsxtManager/policy/api/v1/aaa/ldap-identity-sources/$id"
+            Invoke-RestMethod $uri -Method 'GET' -Headers $nsxtHeaders
+        } else {
+            $uri = "https://$nsxtManager/policy/api/v1/aaa/ldap-identity-sources"
+            (Invoke-RestMethod $uri -Method 'GET' -Headers $nsxtHeaders).results
+        }
+    } Catch {
+        Write-Error $_.Exception.Message
+    }
+}
+Export-ModuleMember -Function Get-NsxtLdap
+
+Function Remove-NsxtLdap {
+    <#
+        .SYNOPSIS
+        Delete LDAP identity source
+
+        .DESCRIPTION
+        The Remove-NsxtLdap cmdlet removes an LDAP identity source
+
+        .EXAMPLE
+        Remove-NsxtLdap -id sfo
+        This example deletes an LDAP identity source 
+    #>
+
+    Param (
+        [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$id
+    )
+
+    Try {
+        $uri = "https://$nsxtManager/policy/api/v1/aaa/ldap-identity-sources/$id"
+        Invoke-RestMethod $uri -Method 'DELETE' -Headers $nsxtHeaders
+    } Catch {
+        Write-Error $_.Exception.Message
+    }
+}
+Export-ModuleMember -Function Remove-NsxtLdap
+
 Function Get-NsxtRole {
     <#
         .SYNOPSIS
@@ -19501,8 +19563,10 @@ Function Get-NsxtRole {
     #>
 
     Try {
+        
         $uri = "https://$nsxtManager/api/v1/aaa/roles"
         (Invoke-RestMethod $uri -Method 'GET' -Headers $nsxtHeaders).results
+
     } Catch {
         Write-Error $_.Exception.Message
     }


### PR DESCRIPTION
### Summary

- Added `Get-NsxtLdap` cmdlet to retrieve LDAP identity providers from NSX Manager.
- Added `Remove-NsxtLdap` cmdlet to remove an LDAP identity provider from NSX Manager.
- Enhanced `Install-vRLIPhotonAgent` cmdlet to support VMware Aria Operations for Logs agent configuration.

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

N/A

### Additional Information

N/A