### PR TITLE
fix: Add-vCenterGlobalPermission

### DIFF
--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.7.0.1014'
+    ModuleVersion = '2.7.0.1015'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -13348,14 +13348,14 @@ Function Add-vCenterGlobalPermission {
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$role,
         [Parameter (Mandatory = $true)] [ValidateSet("true", "false")] [String]$propagate,
         [Parameter (Mandatory = $true)] [ValidateSet("group", "user")] [String]$type,
-		[Parameter (Mandatory = $false)] [Switch]$localDomain = $false
+		[Parameter (Mandatory = $false)] [Switch]$localDomain
     )
 
     Try {
-		if (!$localDomain){
+		if (!$localDomain) {
 			$checkAdAuthentication = Test-ADAuthentication -user $domainBindUser -pass $domainBindPass -server $domain -domain $domain -ErrorAction SilentlyContinue
 			$securePass = ConvertTo-SecureString -String $domainBindPass -AsPlainText -Force
-		    $domainCreds = New-Object System.Management.Automation.PSCredential ($domainBindUser, $securePass)
+            $domainCreds = New-Object System.Management.Automation.PSCredential ($domainBindUser, $securePass)
             if (!($checkAdAuthentication[1] -match "Authentication Successful")) {
 				Write-Error "Unable to authenticate to Active Directory with user ($domainBindUser) and password ($domainBindPass), check details: PRE_VALIDTION_FAILED"
 				Return

--- a/SampleScripts/iam/iamConfigureNsx.ps1
+++ b/SampleScripts/iam/iamConfigureNsx.ps1
@@ -75,8 +75,6 @@ Try {
             $pvsModulePath              = (Get-InstalledModule -Name PowerValidatedSolutions).InstalledLocation
             $allWorkloadDomains         = Get-VCFWorkloadDomain
             $domainFqdn                 = $pnpWorkbook.Workbook.Names["region_ad_child_fqdn"].Value
-            $domainBindUser             = $pnpWorkbook.Workbook.Names["child_svc_vsphere_ad_user"].Value
-            $domainBindPass             = $pnpWorkbook.Workbook.Names["child_svc_vsphere_ad_password"].Value
             $mgmtSddcDomainName         = $pnpWorkbook.Workbook.Names["mgmt_sddc_domain"].Value
             $wldSddcDomainName          = $pnpWorkbook.Workbook.Names["wld_sddc_domain"].Value
             $wsaFqdn                    = $pnpWorkbook.Workbook.Names["region_wsa_fqdn"].Value


### PR DESCRIPTION
### Summary

- Fixed an issue with recent change of `Add-vCenterGlobalPermission` where `-localDomain` switch was always set to false


### Type

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

N/A

### Additional Information
N/a
