### PR TITLE
fix: error adding an overlay-backed nsx segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Added `Remove-NsxtLdap` cmdlet to remove an LDAP identity provider from NSX Manager.
 - Enhanced `Install-vRLIPhotonAgent` cmdlet to support VMware Aria Operations for Logs agent configuration.
 - Updated `Add-vCenterGlobalPermission` cmdlet and examples with domainBindUser and domainBindUsePass as optional parameters for a local domain (_e.g._, `vsphere.local`) user.
+- Fixed `Add-NetworkSegment` cmdlet where it was unable to add a new overlay segment with NSX 4.1.2.
 
 ## v2.6.0
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.7.0.1017'
+    ModuleVersion = '2.7.0.1018'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -19890,7 +19890,7 @@ Function New-NsxtSegment {
         $uri = "https://$nsxtManager/policy/api/v1/infra/segments/$Name"
         $response = Invoke-WebRequest -Method PATCH -URI $uri -ContentType application/json -Body $json -headers $nsxtHeaders
         if ($response.StatusCode -eq 200 -or $response.StatusCode -eq 204) {
-            Write-Output "NSX-T Segment $Name successfully created."
+            Write-Output "NSX Segment $Name successfully created."
         }
     } Catch {
         Write-Error $_.Exception.Message

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -5034,7 +5034,7 @@ Function Add-NetworkSegment {
                                 if ($tierGatewayExists) {
                                     $validateTransportZone = Get-NsxtTransportZone -Name $transportZone -ErrorAction SilentlyContinue
                                     if ($validateTransportZone.display_name -eq $transportZone) {
-                                        if ($validateTransportZone.transport_type -ne $segmentType.ToUpper()){
+                                        if ($validateTransportZone.tz_type -notmatch $segmentType.ToUpper()){
                                             Write-Error "NSX Transport Zone $transportZone does not match the defined segment Type $segmentType in NSX Manager ($($vcfNsxtDetails.fqdn)): PRE_VALIDATION_FAILED"
                                             Break
                                         }
@@ -19808,11 +19808,11 @@ Function Get-NsxtTransportZone {
 
     Try {
         if (!$PsBoundParameters.ContainsKey("name")) {
-            $uri = "https://$nsxtManager/api/v1/transport-zones"
+            $uri = "https://$nsxtManager/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones"
             $response = Invoke-RestMethod -Method GET -URI $uri -ContentType application/json -headers $nsxtHeaders
             $response.results | Sort-Object display_name
         } elseif ($PsBoundParameters.ContainsKey("Name")) {
-            $uri = "https://$nsxtManager/api/v1/transport-zones"
+            $uri = "https://$nsxtManager/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones"
             $response = Invoke-RestMethod -Method GET -URI $uri -ContentType application/json -headers $nsxtHeaders
             $responseChecked = $response.results | Where-Object { $_.display_name -eq $name }
 
@@ -19861,7 +19861,7 @@ Function New-NsxtSegment {
         Write-Error "Gateway type not defined"
     }
 
-    $transportZoneId = (Get-NsxtTransportZone -Name $TransportZone).id
+    $transportZonePath = (Get-NsxtTransportZone -Name $TransportZone).path
 
     if ($SegmentType -match "overlay") {
         $json = @"
@@ -19869,7 +19869,7 @@ Function New-NsxtSegment {
 "display_name" : "$Name",
 "subnets" : [{ "gateway_address" : "$Cidr" }],
 "connectivity_path" : "$connectivityPath",
-"transport_zone_path" : "/infra/sites/default/enforcement-points/default/transport-zones/$transportZoneId"
+"transport_zone_path" : "$transportZonePath"
 }
 "@
 
@@ -19878,7 +19878,7 @@ Function New-NsxtSegment {
 {
 "display_name" : "$Name",
 "vlan_ids" : [ "$VlanId" ],
-"transport_zone_path" : "/infra/sites/default/enforcement-points/default/transport-zones/$transportZoneId"
+"transport_zone_path" : "$transportZonePath"
 }
 "@
 
@@ -19888,8 +19888,10 @@ Function New-NsxtSegment {
 
     Try {
         $uri = "https://$nsxtManager/policy/api/v1/infra/segments/$Name"
-        $response = Invoke-RestMethod -Method PUT -URI $uri -ContentType application/json -Body $json -headers $nsxtHeaders
-        $response
+        $response = Invoke-WebRequest -Method PATCH -URI $uri -ContentType application/json -Body $json -headers $nsxtHeaders
+        if ($response.StatusCode -eq 200 -or $response.StatusCode -eq 204) {
+            Write-Output "NSX-T Segment $Name successfully created."
+        }
     } Catch {
         Write-Error $_.Exception.Message
     }


### PR DESCRIPTION
- Update `Add-NetworkSegment` to compare segment type w/ `tz_type` property.
- Change `New-NsxtSegment` to dynamically populate TZ path.
- Change `New-NsxtSegment` to use `PATCH` method instead of `PUT`.
- Change `New-NsxtSegement` to look for HTTP 200/204 indicating success.
- Update `Get-NsxtTransportZone` to retrieve values using the proper URI.

Ref #365

### Summary

Resolved issue adding an overlay-backed NSX segment

### Type

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

Ensured Add-NetworkSegment worked properly with VCF 4.5.2, 5.0.0, and 5.1.0

### Issue References

Closes #365 

### Additional Information

None