### PR TITLE
fix: add aria suite load balancer controller type

### DIFF
--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.7.0.1020'
+    ModuleVersion = '2.7.0.1021'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -9559,7 +9559,8 @@ Function Export-vROPsJsonSpec {
                                                 #### Generate VMware Aria Operations Cluster Details
                                                 $clusterVipProperties = @()
                                                 $clusterVipProperties += [pscustomobject]@{
-                                                    'hostName'	= $pnpWorkbook.Workbook.Names["xreg_vrops_virtual_fqdn"].Value
+                                                    'controllerType'    = "NSX_T"
+                                                    'hostName'	        = $pnpWorkbook.Workbook.Names["xreg_vrops_virtual_fqdn"].Value
                                                 }
                                                 $clusterVipsObject = @()
                                                 $clusterVipsObject += [pscustomobject]@{


### PR DESCRIPTION
### Summary

- Enhance `Export-vROPsJsonSpec` JSON spec with new `controllerType` equals NSX_T
- 
NOTE: No update to CHANGELOG.md as this is part of VMware Cloud Foundation 5.1 Support

### Type

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

N/A

### Additional Information

N/A
