### PR TITLE
feat: add get-nsxtldap to create nsx identity source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `Add-vROPSVcenterCredential` cmdlet to create a VMware Cloud Foundation credential in VMware Aria Operations.
 - Added `Get-NsxtLdap` cmdlet to retrieve LDAP identity providers from NSX Manager.
 - Added `Remove-NsxtLdap` cmdlet to remove an LDAP identity provider from NSX Manager.
+- Added `New-NsxtLdap` cmdlet to create an LDAP/LDAPS Identity Source in NSX Manager
 - Updated cmdlet descriptions and examples for VMware Aria Suite, formerly known as vRealize Suite, products to use the new VMware Aria names.
   Note: No changes to the names of the cmdlets.
 - Enhanced `Request-VrmsToken` to use `-skipCertificateCheck` switch if `$PSEdition` is "Core".
@@ -20,8 +21,8 @@
 - Enhanced `Add-ContentLibrary` cmdlet to check the VMware Cloud Foundation version when adding a subscribed content library. If the version is 5.0.0 or later and the `-subscriptionUrl` parameter is set to `wp-content.vmware.com`, a warning message is displayed and the cmdlet exits.
 - Enhanced `Add-ContentLibrary` cmdlet to work on both PowerShell 7 and Windows PowerShell 5.1.
 - Enhanced `Register-vROPSManagementPack` cmdlet to enable or disable the VMware Cloud Foundation management pack.
-- Enhanced `Undo-vROPSAdapter` cmdlet to support vCenter Server and vSAN adapter types in Aria Operations.
-- Enhanced `Undo-vROPSCredential` cmdlet to support vCenter Server and vSAN credential types in Aria Operations.
+- Enhanced `Undo-vROPSAdapter` cmdlet to support vCenter Server and vSAN adapter types in VMware Aria Operations.
+- Enhanced `Undo-vROPSCredential` cmdlet to support vCenter Server and vSAN credential types in VMware Aria Operations.
 - Enhanced sample alerts and notification in `SampleNotifications/*` to reflect the new VMware Aria product names.
   - `vrli-vcf-datacenter.json` -> `aria-operations-logs-alerts-datacenter-vcf.json`
   - `vrli-iom-alerts.json` -> `aria-operations-logs-alerts-iom.json`

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.7.0.1021'
+    ModuleVersion = '2.7.0.1022'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
### Summary

- Added `New-NsxtLdap` cmdlet to create an LDAP/LDAPS Identity Source in NSX Manager

### Type

- [ ] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

### Test and Documentation

<img width="1450" alt="image" src="https://github.com/vmware/power-validated-solutions-for-cloud-foundation/assets/31245616/0e461bfd-40c0-4340-a752-160356a118c2">

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

N/A

### Additional Information

N/A
