### PR TITLE
fix: error enabling Harbor Registry Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 > Release Date: Unreleased
 
+- Fixed issue where the embedded Harbor Registry failed to deploy on vSphere 8.0 and up on the following cmdlets:
+  - `Enable-WMRegistry`
+  - `Get-WMRegsitry`
+  - `Remove-WMRegistry`
+  - `Get-WMRegsitryHealth`
 - Fixed `Add-NetworkSegment` cmdlet where it was unable to add a new overlay segment with NSX 4.1.2.
 - Fixed `New-vRSLCMDatacenterVcenter` cmdlet to wait for datacenter to be created before adding the vCenter.
 - Added `Add-vROPSVcfCredential` cmdlet to create a VMware Cloud Foundation credential in VMware Aria Operations.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.7.0.1022'
+    ModuleVersion = '2.7.0.1023'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -23189,6 +23189,11 @@ Function Enable-WMRegistry {
         $cluster = $inputObject.Name
     }
 
+    if ($vCenterApi -ge 800) {
+        Write-Warning "The embedded Harbor registry is not supported on vSphere 8.0 and higher: SKIPPED"
+        break
+    }
+
     Try {
         if ($vCenterApi -le 701) {
             $getHarborInstalled = (Invoke-RestMethod -Method GET -URI https://$vcApiServer/rest/vcenter/content/registries/harbor -Headers $vcApiHeaders).value
@@ -23314,6 +23319,11 @@ Function Get-WMRegistry {
         $cluster = $inputObject.Name
     }
 
+    if ($vCenterApi -ge 800) {
+        Write-Warning "The embedded Harbor registry is not supported on vSphere 8.0 and higher: SKIPPED"
+        break
+    }
+
     if ($Cluster) {
         Try {
             $wmClusterId = (Invoke-RestMethod -Method GET -URI  https://$vcApiServer/api/vcenter/namespace-management/clusters -Headers $vcApiHeaders | Where-Object { $_.cluster_name -eq $Cluster }).cluster
@@ -23373,6 +23383,11 @@ Function Remove-WMRegistry {
     )
 
     Try {
+        if ($vCenterApi -ge 800) {
+            Write-Warning "The embedded Harbor registry is not supported on vSphere 8.0 and higher: SKIPPED"
+            break
+        }
+
         if ($inputObject) {
             $harborRegistryId = $inputObject.registry
         }
@@ -23419,6 +23434,11 @@ Function Get-WMRegistryHealth {
     )
 
     Try {
+        if ($vCenterApi -ge 800) {
+            Write-Warning "The embedded Harbor registry is not supported on vSphere 8.0 and higher: SKIPPED"
+            break
+        }
+        
         if ($inputObject) {
             $registry = $inputObject.registry
         }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

### Summary

Fixed issue where the embedded Harbor Registry failed to deploy on vSphere 8.0 and up on the following cmdlets:
  - `Enable-WMRegistry`
  - `Get-WMRegsitry`
  - `Remove-WMRegistry`
  - `Get-WMRegsitryHealth`

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

Tested functionality and regression in VCF 4.5.2, 5.0, and 5.1

### Issue References


Closes #369 

### Additional Information

None
