### PR TITLE
fix: remove secondary ntp from export-vropsjsonspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed `Add-WorkspaceOneRole` cmdlet where a blank line is returned due to no API response data.
 - Fixed `Undo-vCenterGlobalPermission` cmdlet where incorrect input variable is checked.
 - Fixed `Set-NsxtRole` cmdlet where missing input commands were missing from the example.
+- Fixed `Export-vROPSJsonSpec` cmdlet to not populate secondary NTP server address from the Planning and Preparation workbook.
 - Added `Export-IamJsonSpec` cmdlet to generate a JSON specification file for Identify and Access Management.
 - Added `Invoke-IamDeployment` cmdlet to perform an end-to-end deployment of Identify and Access Management.
 - Added `Invoke-UndoIamDeployment` cmdlet to perform removal of  Identify and Access Management.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.8.0.1000'
+    ModuleVersion = '2.8.0.1001'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -9595,12 +9595,7 @@ Function Export-vROPsJsonSpec {
                                                 $masterProperties | Add-Member -notepropertyname 'vCenterName' -notepropertyvalue ($pnpWorkbook.Workbook.Names["mgmt_vc_fqdn"].Value).Split(".")[0]
                                                 $masterProperties | Add-Member -notepropertyname 'vcUsername' -notepropertyvalue $vcCredentials.userName
                                                 $masterProperties | Add-Member -notepropertyname 'vcPassword' -notepropertyvalue ("locker:password:" + $($vcCredentials.vmid) + ":" + $($vcCredentials.alias))
-                                                if ($null -eq $pnpWorkbook.Workbook.Names["xregion_ntp2_server"].Value) {
-                                                    $masterProperties | Add-Member -notepropertyname 'ntp' -notepropertyvalue $pnpWorkbook.Workbook.Names["xregion_ntp1_server"].Value
-                                                }
-                                                else {
-                                                    $masterProperties | Add-Member -notepropertyname 'ntp' -notepropertyvalue ($pnpWorkbook.Workbook.Names["xregion_ntp1_server"].Value + "," + $pnpWorkbook.Workbook.Names["xregion_ntp2_server"].Value)
-                                                }
+                                                $masterProperties | Add-Member -notepropertyname 'ntp' -notepropertyvalue $pnpWorkbook.Workbook.Names["xregion_ntp1_server"].Value
                                                 if ($vcfVersion -eq "4.4.0") {
                                                     $masterProperties | Add-Member -notepropertyname 'extendedStorage' -notepropertyvalue $pnpWorkbook.Workbook.Names["mgmt_vsan_datastore"].Value
                                                 }
@@ -9630,7 +9625,7 @@ Function Export-vROPsJsonSpec {
                                                     'ip'		    = $pnpWorkbook.Workbook.Names["region_vropsca_ip"].Value
                                                     'deployOption'  = $deployOption
                                                     'gateway'       = $pnpWorkbook.Workbook.Names["reg_seg01_gateway_ip"].Value
-                                                    'domain'        = $pnpWorkbook.Workbook.Names["region_ad_parent_fqdn"].Value
+                                                    'domain'        = $pnpWorkbook.Workbook.Names["region_ad_child_fqdn"].Value
                                                     'searchpath'    = $pnpWorkbook.Workbook.Names["region_ad_child_fqdn"].Value
                                                     'dns'           = ($pnpWorkbook.Workbook.Names["region_dns1_ip"].Value + "," + $pnpWorkbook.Workbook.Names["region_dns2_ip"].Value)
                                                     'netmask'       = $pnpWorkbook.Workbook.Names["reg_seg01_mask_overlay_backed"].Value
@@ -9652,7 +9647,7 @@ Function Export-vROPsJsonSpec {
                                                     'ip'		= $pnpWorkbook.Workbook.Names["region_vropscb_ip"].Value
                                                     'deployOption'  = $deployOption
                                                     'gateway'       = $pnpWorkbook.Workbook.Names["reg_seg01_gateway_ip"].Value
-                                                    'domain'        = $pnpWorkbook.Workbook.Names["region_ad_parent_fqdn"].Value
+                                                    'domain'        = $pnpWorkbook.Workbook.Names["region_ad_child_fqdn"].Value
                                                     'searchpath'    = $pnpWorkbook.Workbook.Names["region_ad_child_fqdn"].Value
                                                     'dns'           = ($pnpWorkbook.Workbook.Names["region_dns1_ip"].Value + "," + $pnpWorkbook.Workbook.Names["region_dns2_ip"].Value)
                                                     'netmask'       = $pnpWorkbook.Workbook.Names["reg_seg01_mask_overlay_backed"].Value


### PR DESCRIPTION
### Summary

- Fixed `Export-vROPSJsonSpec` cmdlet to not populate secondary NTP server address from the Planning and Preparation workbook.

### Type

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

N/A

### Additional Information

N/A
