### PR TITLE
feat: add ldap support for nsx manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - Added `Remove-vRLIAuthenticationAD` cmdlet to disable Active Directory as an authentication provider in VMware Aria Operations for Logs.
 - Added `Add-vRLIAuthenticationAD` cmdlet to enable and configure Active Directory as an authentication provider in VMware Aria Operations for Logs.
 - Added `Undo-vRLIAuthenticationAD` cmdlet to disable Active Directory as an authentication provider in VMware Aria Operations for Logs.
+- Added `Add-NsxtLdapRole` cmdlet to assign an LDAP user or group role-based access control in NSX Manager.
+- Added `Undo-NsxtLdapRole` cmdlet to remove an LDAP user or group role-based access control from NSX Manager.
 - Enhanced `Add-WorkspaceOneRole` cmdlet for better pre and post validation.
 - Enhanced `Add-vRLIAuthenticationWSA` cmdlet to check for connectivity and authentication to Workspace ONE Access.
 - Enhanced `Set-NsxtRole` cmdlet to support adding roles to LDAP users.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.8.0.1006'
+    ModuleVersion = '2.8.0.1007'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
### Summary

- Added `Add-NsxtLdapRole` cmdlet to assign an LDAP user or group role-based access control in NSX Manager.
- Added `Undo-NsxtLdapRole` cmdlet to remove an LDAP user or group role-based access control from NSX Manager.

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

`Add-NsxtLdapRole`

<img width="1534" alt="image" src="https://github.com/vmware/power-validated-solutions-for-cloud-foundation/assets/31245616/49e9cfb8-887f-47b8-8a59-3f45a04f4228">

<img width="1271" alt="image" src="https://github.com/vmware/power-validated-solutions-for-cloud-foundation/assets/31245616/ab784824-0848-45ba-9ed4-deb8cec9883d">

`Undo-NsxtLdapRole` 

<img width="1533" alt="image" src="https://github.com/vmware/power-validated-solutions-for-cloud-foundation/assets/31245616/14167a8c-1f7c-4996-b1bc-44f536d7dfc9">

<img width="1275" alt="image" src="https://github.com/vmware/power-validated-solutions-for-cloud-foundation/assets/31245616/a9a3bf9f-bf30-44e5-80d7-1bc6094ca3d7">

### Issue References

N/A

### Additional Information

N/A