### PR TITLE
feat: add undo-vrliauthenticationwsa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Added `Undo-vRLIAuthenticationAD` cmdlet to disable Active Directory as an authentication provider in VMware Aria Operations for Logs.
 - Added `Add-NsxtLdapRole` cmdlet to assign an LDAP user or group role-based access control in NSX Manager.
 - Added `Undo-NsxtLdapRole` cmdlet to remove an LDAP user or group role-based access control from NSX Manager.
+- Added `Undo-vRLIAuthenticationWSA` cmdlet to support disable Workspace ONE Access integration with VMware Aria Operations for Logs.
 - Enhanced `Add-WorkspaceOneRole` cmdlet for better pre and post validation.
 - Enhanced `Add-vRLIAuthenticationWSA` cmdlet to check for connectivity and authentication to Workspace ONE Access.
 - Enhanced `Set-NsxtRole` cmdlet to support adding roles to LDAP users.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.8.0.1007'
+    ModuleVersion = '2.8.0.1008'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
### Summary

- Added `Undo-vRLIAuthenticationWSA` cmdlet to support disable Workspace ONE Access integration with VMware Aria Operations for Logs.

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

<img width="1135" alt="image" src="https://github.com/vmware/power-validated-solutions-for-cloud-foundation/assets/31245616/53a769ec-e6dc-40a6-baf2-a6a6c94fffe4">

### Issue References

N/A

### Additional Information

N/A
