### PR TITLE
feat: add support for aria suite lifecycle load balancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Added `Add-NsxtLdapRole` cmdlet to assign an LDAP user or group role-based access control in NSX Manager.
 - Added `Undo-NsxtLdapRole` cmdlet to remove an LDAP user or group role-based access control from NSX Manager.
 - Added `Undo-vRLIAuthenticationWSA` cmdlet to support disable Workspace ONE Access integration with VMware Aria Operations for Logs.
-- Added `Get-vRSLCMLoadbalancer` cmdlet to support retrieving a list of load balancers configure in VMware Aria Suite Lifecycle.
+- Added `Get-vRSLCMLoadbalancer` cmdlet to support retrieving a list of load balancers configured in VMware Aria Suite Lifecycle.
 - Added `New-vRSLCMLoadbalancer` cmdlet to support adding a new load balancer to VMware Aria Suite Lifecycle.
 - Added `Remove-vRSLCMLoadbalancer` cmdlet to support removing a load balancer from VMware Aria Suite Lifecycle.
 - Enhanced `Add-WorkspaceOneRole` cmdlet for better pre and post validation.
@@ -39,9 +39,9 @@
 - Enhanced `Remove-vRLIGroup` cmdlet to support v2 API for removing group membership by authentication provider in VMware Aria Operations for Logs.
 - Enhanced `Add-vRLIAuthenticationGroup` cmdlet to support updated `Add-vRLIGroup` cmdlet usage and Active Directory support.
 - Enhanced `New-WSADeployment` cmdlet to better handle checking for and reporting a missing Cross-Instance Datacenter.
-- Enhanced `New-WSADeployment` cmdlet to check for existence of the a load balancer in VMware Aria Suite Lifecycle and if missing create it.
-- Enhanced `New-vROPSDeployment` cmdlet to check for existence of the a load balancer in VMware Aria Suite Lifecycle and if missing create it.
-- Enhanced `New-vRADeployment` cmdlet to check for existence of the a load balancer in VMware Aria Suite Lifecycle and if missing create it.
+- Enhanced `New-WSADeployment` cmdlet to check for the existence of a load balancer in VMware Aria Suite Lifecycle and if missing create it.
+- Enhanced `New-vROPSDeployment` cmdlet to check for the existence of the a load balancer in VMware Aria Suite Lifecycle and if missing create it.
+- Enhanced `New-vRADeployment` cmdlet to check for the existence of the a load balancer in VMware Aria Suite Lifecycle and if missing create it.
 
 ## v2.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 - Added `Add-NsxtLdapRole` cmdlet to assign an LDAP user or group role-based access control in NSX Manager.
 - Added `Undo-NsxtLdapRole` cmdlet to remove an LDAP user or group role-based access control from NSX Manager.
 - Added `Undo-vRLIAuthenticationWSA` cmdlet to support disable Workspace ONE Access integration with VMware Aria Operations for Logs.
+- Added `Get-vRSLCMLoadbalancer` cmdlet to support retrieving a list of load balancers configure in VMware Aria Suite Lifecycle.
+- Added `New-vRSLCMLoadbalancer` cmdlet to support adding a new load balancer to VMware Aria Suite Lifecycle.
+- Added `Remove-vRSLCMLoadbalancer` cmdlet to support removing a load balancer from VMware Aria Suite Lifecycle.
 - Enhanced `Add-WorkspaceOneRole` cmdlet for better pre and post validation.
 - Enhanced `Add-vRLIAuthenticationWSA` cmdlet to check for connectivity and authentication to Workspace ONE Access.
 - Enhanced `Set-NsxtRole` cmdlet to support adding roles to LDAP users.
@@ -35,7 +38,10 @@
 - Enhanced `Add-vRLIGroup` cmdlet to support v2 API for adding group membership by authentication provider in VMware Aria Operations for Logs.
 - Enhanced `Remove-vRLIGroup` cmdlet to support v2 API for removing group membership by authentication provider in VMware Aria Operations for Logs.
 - Enhanced `Add-vRLIAuthenticationGroup` cmdlet to support updated `Add-vRLIGroup` cmdlet usage and Active Directory support.
-- Enhanced `New-WSADeployment` cmdlet to better handle checking for reporting a missing Cross-Instance Datacenter.
+- Enhanced `New-WSADeployment` cmdlet to better handle checking for and reporting a missing Cross-Instance Datacenter.
+- Enhanced `New-WSADeployment` cmdlet to check for existence of the a load balancer in VMware Aria Suite Lifecycle and if missing create it.
+- Enhanced `New-vROPSDeployment` cmdlet to check for existence of the a load balancer in VMware Aria Suite Lifecycle and if missing create it.
+- Enhanced `New-vRADeployment` cmdlet to check for existence of the a load balancer in VMware Aria Suite Lifecycle and if missing create it.
 
 ## v2.7.1
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.8.0.1009'
+    ModuleVersion = '2.8.0.1010'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -26234,8 +26234,7 @@ Function Get-vRSLCMLoadbalancer {
     Try {
         $uri = "https://$vrslcmAppliance/lcm/lcops/api/controller/all?isAvailable=$available&type=$type"
         Invoke-RestMethod $uri -Method 'GET' -Headers $vrslcmHeaders
-    }
-    Catch {
+    } Catch {
         Write-Error $_.Exception.Message
     }
 }
@@ -26275,8 +26274,7 @@ Function New-vRSLCMLoadbalancer {
             "controllerID": ""
         }'
         Invoke-RestMethod $uri -Method 'POST' -Headers $vrslcmHeaders -Body $body
-    }
-    Catch {
+    } Catch {
         Write-Error $_.Exception.Message
     }
 }
@@ -26304,8 +26302,7 @@ Function Remove-vRSLCMLoadbalancer {
         $controllerId = ((Get-vRSLCMLoadbalancer -type $type) | Where-Object {$_.loadBalancerDetails -match $loadBalancerFqdn}).controller_id
         $uri = "https://$vrslcmAppliance/lcm/lcops/api/controller/loadbalancer/delete?controllerID=$controllerId&loadBalancerFQDN=$loadBalancerFqdn"
         Invoke-RestMethod $uri -Method 'DELETE' -Headers $vrslcmHeaders
-    }
-    Catch {
+    } Catch {
         Write-Error $_.Exception.Message
     }
 }

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -11066,6 +11066,12 @@ Function New-vROPSDeployment {
                             $jsonSpecFileName = (((Get-VCFWorkloadDomain | Where-Object {$_.type -eq "MANAGEMENT"}).name) + "-" + "vropsDeploymentSpec.json")
                             $json = (Get-Content -Raw $jsonSpecFileName)
                             $jsonSpec = $json | ConvertFrom-Json
+                            $pnpWorkbook = Open-ExcelPackage -Path $workbook
+                            $loadBalancerFqdn = $pnpWorkbook.Workbook.Names["xreg_vrops_virtual_fqdn"].Value
+                            $loadBalancerIp = $pnpWorkbook.Workbook.Names["xreg_vrops_virtual_ip"].Value
+                            if (!(((Get-vRSLCMLoadbalancer -type NSX_T) | Where-Object {$_.loadBalancerDetails -match $loadBalancerFqdn}))) {
+                                New-vRSLCMLoadbalancer -type NSX_T -loadBalancerIp $loadBalancerIp -loadBalancerFqdn $loadBalancerFqdn | Out-Null
+                            }
                             if (!((Get-vRSLCMEnvironment | Where-Object {$_.environmentName -eq $jsonSpec.environmentName}).products.id -contains $jsonSpec.products.id)) {
                                 if (Get-vRSLCMLockerPassword -alias $($jsonSpec.products.properties.productPassword.Split(":")[3])) {
                                     if (Get-vRSLCMLockerCertificate | Where-Object {$_.alias -Match $($jsonSpec.products.properties.certificate.Split(":")[3])}) {
@@ -13546,6 +13552,12 @@ Function New-vRADeployment {
                             $jsonSpecFileName = (((Get-VCFWorkloadDomain | Where-Object {$_.type -eq "MANAGEMENT"}).name) + "-" + "vraDeploymentSpec.json")
                             $json = (Get-Content -Raw $jsonSpecFileName)
                             $jsonSpec = $json | ConvertFrom-Json
+                            $pnpWorkbook = Open-ExcelPackage -Path $workbook
+                            $loadBalancerFqdn = $pnpWorkbook.Workbook.Names["xreg_vra_virtual_fqdn"].Value
+                            $loadBalancerIp = $pnpWorkbook.Workbook.Names["xreg_vra_virtual_ip"].Value
+                            if (!(((Get-vRSLCMLoadbalancer -type NSX_T) | Where-Object {$_.loadBalancerDetails -match $loadBalancerFqdn}))) {
+                                New-vRSLCMLoadbalancer -type NSX_T -loadBalancerIp $loadBalancerIp -loadBalancerFqdn $loadBalancerFqdn | Out-Null
+                            }
                             if (!((Get-vRSLCMEnvironment | Where-Object {$_.environmentName -eq $jsonSpec.environmentName}).products.id -contains $jsonSpec.products.id)) {
                                 if (Get-vRSLCMLockerPassword -alias $($jsonSpec.products.properties.productPassword.Split(":")[3])) {
                                     if (Get-vRSLCMLockerCertificate | Where-Object {$_.alias -Match $($jsonSpec.products.properties.certificate.Split(":")[3])}) {
@@ -26200,6 +26212,105 @@ Function Remove-vRSLCMEnvironment {
 }
 Export-ModuleMember -Function Remove-vRSLCMEnvironment
 
+
+Function Get-vRSLCMLoadbalancer {
+    <#
+        .SYNOPSIS
+        Get paginated list of load balancers from VMware Aria Suite Lifecycle
+
+        .DESCRIPTION
+        The Get-vRSLCMLoadbalancer cmdlet gets a paginated list of load balancers from VMware Aria Suite Lifecycle
+
+        .EXAMPLE
+        Get-vRSLCMLoadbalancer -type NSX_T
+        This example gets all load balancers in VMware Aria Suite Lifecycle with a type of NSX_T
+    #>
+
+    Param (
+        [Parameter (Mandatory = $true)] [ValidateSet('NSX_T','NSX_ALB','OTHERS')] [String]$type,
+        [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [Bool]$available=$false
+    )
+
+    Try {
+        $uri = "https://$vrslcmAppliance/lcm/lcops/api/controller/all?isAvailable=$available&type=$type"
+        Invoke-RestMethod $uri -Method 'GET' -Headers $vrslcmHeaders
+    }
+    Catch {
+        Write-Error $_.Exception.Message
+    }
+}
+Export-ModuleMember -Function Get-vRSLCMLoadbalancer
+
+Function New-vRSLCMLoadbalancer {
+    <#
+        .SYNOPSIS
+        Add a load balancer to VMware Aria Suite Lifecycle
+
+        .DESCRIPTION
+        The New-vRSLCMLoadbalancer cmdlet adds a new loadbalancers to VMware Aria Suite Lifecycle
+
+        .EXAMPLE
+        New-vRSLCMLoadbalancer -type NSX_T -loadBalancerIp 192.168.11.60 -loadBalancerFqdn xint-wsa01.rainpole.io
+        This example adds load balancers in VMware Aria Suite Lifecycle with a type of NSX_T
+    #>
+
+    Param (
+        [Parameter (Mandatory = $true)] [ValidateSet('NSX_T')] [String]$type,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$loadBalancerIp,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$loadBalancerFqdn
+    )
+
+    Try {
+        $uri = "https://$vrslcmAppliance/lcm/lcops/api/controller/save"
+        $Global:body = ' {
+            "type": "'+ $type +'",
+            "userName": "",
+            "controllerFqdn": "",
+            "passwordReference": "",
+            "loadBalancerFQDN": "'+ $loadBalancerFqdn +'",
+            "loadBalancerIP": "'+ $loadBalancerIp +'",
+            "controllerMeta": {},
+            "loadBalancerMeta": {},
+            "controllerIP": "",
+            "controllerID": ""
+        }'
+        Invoke-RestMethod $uri -Method 'POST' -Headers $vrslcmHeaders -Body $body
+    }
+    Catch {
+        Write-Error $_.Exception.Message
+    }
+}
+Export-ModuleMember -Function New-vRSLCMLoadbalancer
+
+Function Remove-vRSLCMLoadbalancer {
+    <#
+        .SYNOPSIS
+        Delete a load balancer from VMware Aria Suite Lifecycle
+
+        .DESCRIPTION
+        The Remove-vRSLCMLoadbalancer cmdlet removes a load balancer from VMware Aria Suite Lifecycle
+
+        .EXAMPLE
+        Remove-vRSLCMLoadbalancer -type NSX_T -loadBalancerFqdn xint-wsa01.rainpole.io
+        This example deletes the load balancer from VMware Aria Suite Lifecycle
+    #>
+
+    Param (
+        [Parameter (Mandatory = $true)] [ValidateSet('NSX_T','NSX_ALB','OTHERS')] [String]$type,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$loadBalancerFqdn
+    )
+
+    Try {
+        $controllerId = ((Get-vRSLCMLoadbalancer -type $type) | Where-Object {$_.loadBalancerDetails -match $loadBalancerFqdn}).controller_id
+        $uri = "https://$vrslcmAppliance/lcm/lcops/api/controller/loadbalancer/delete?controllerID=$controllerId&loadBalancerFQDN=$loadBalancerFqdn"
+        Invoke-RestMethod $uri -Method 'DELETE' -Headers $vrslcmHeaders
+    }
+    Catch {
+        Write-Error $_.Exception.Message
+    }
+}
+Export-ModuleMember -Function Remove-vRSLCMLoadbalancer
+
 Function Get-vRSLCMRequest {
     <#
         .SYNOPSIS
@@ -26674,7 +26785,13 @@ Function New-WSADeployment {
                                 $commandSwitch = $commandSwitch + " -useContentLibrary -contentLibrary $contentLibrary"
                             }
                             Invoke-Expression "Export-WSAJsonSpec -server $server -user $user -pass $pass -workbook $workbook $($commandSwitch) -ErrorAction SilentlyContinue -ErrorVariable ErrorMsg"
-                            if (!$ErrorMsg) { 
+                            if (!$ErrorMsg) {
+                                $pnpWorkbook = Open-ExcelPackage -Path $workbook
+                                $loadBalancerFqdn = $pnpWorkbook.Workbook.Names["xreg_wsa_virtual_fqdn"].Value
+                                $loadBalancerIp = $pnpWorkbook.Workbook.Names["xreg_wsa_virtual_ip"].Value
+                                if (!(((Get-vRSLCMLoadbalancer -type NSX_T) | Where-Object {$_.loadBalancerDetails -match $loadBalancerFqdn}))) {
+                                    New-vRSLCMLoadbalancer -type NSX_T -loadBalancerIp $loadBalancerIp -loadBalancerFqdn $loadBalancerFqdn | Out-Null
+                                }
                                 $jsonSpecFileName = (((Get-VCFWorkloadDomain | Where-Object {$_.type -eq "MANAGEMENT"}).name) + "-" + "wsaDeploymentSpec.json")
                                 $json = (Get-Content -Raw $jsonSpecFileName)
                                 $jsonSpec = $json | ConvertFrom-Json
@@ -31425,7 +31542,7 @@ Function Set-vRLIAuthenticationAD {
     )
 
     Try {
-        $Global:jsonSpec = New-Object -TypeName psobject
+        $jsonSpec = New-Object -TypeName psobject
         $jsonSpec | Add-Member -notepropertyname 'enableAD' -notepropertyvalue $true
         $jsonSpec | Add-Member -notepropertyname 'domain' -notepropertyvalue $domain
         $jsonSpec | Add-Member -notepropertyname 'domainServers' -notepropertyvalue $domainServers


### PR DESCRIPTION
### Summary

- Added `Get-vRSLCMLoadbalancer` cmdlet to support retrieving a list of load balancers configure in VMware Aria Suite Lifecycle.
- Added `New-vRSLCMLoadbalancer` cmdlet to support adding a new load balancer to VMware Aria Suite Lifecycle.
- Added `Remove-vRSLCMLoadbalancer` cmdlet to support removing a load balancer from VMware Aria Suite Lifecycle.
- Enhanced `New-WSADeployment` cmdlet to check for existence of the a load balancer in VMware Aria Suite Lifecycle and if missing create it.
- Enhanced `New-vROPSDeployment` cmdlet to check for existence of the a load balancer in VMware Aria Suite Lifecycle and if missing create it.
- Enhanced `New-vRADeployment` cmdlet to check for existence of the a load balancer in VMware Aria Suite Lifecycle and if missing create it.

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

N/A

### Additional Information

N/A
