### PR TITLE
feat: add aris suite lifecycle data collection and ssh apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 - Added `Get-vRSLCMLoadbalancer` cmdlet to support retrieving a list of load balancers configured in VMware Aria Suite Lifecycle.
 - Added `New-vRSLCMLoadbalancer` cmdlet to support adding a new load balancer to VMware Aria Suite Lifecycle.
 - Added `Remove-vRSLCMLoadbalancer` cmdlet to support removing a load balancer from VMware Aria Suite Lifecycle.
+- Added `Sync-vRSLCMDatacenterVcenter` cmdlet to trigger a data collection of a vCenter Server in VMware Aria Suite Lifecycle.
+- Added `Get-vRSLCMSshStatus` cmdlet to retrieve the status of the SSH service for VMware Aria Suite Lifecycle.
+- Added `Set-vRSLCMSshStatus` cmdlet to disable or enable the SSH service for VMware Aria Suite Lifecycle.
 - Enhanced `Add-WorkspaceOneRole` cmdlet for better pre and post validation.
 - Enhanced `Add-vRLIAuthenticationWSA` cmdlet to check for connectivity and authentication to Workspace ONE Access.
 - Enhanced `Set-NsxtRole` cmdlet to support adding roles to LDAP users.
@@ -39,11 +42,13 @@
 - Enhanced `Add-vRLIGroup` cmdlet to support v2 API for adding group membership by authentication provider in VMware Aria Operations for Logs.
 - Enhanced `Remove-vRLIGroup` cmdlet to support v2 API for removing group membership by authentication provider in VMware Aria Operations for Logs.
 - Enhanced `Add-vRLIAuthenticationGroup` cmdlet to support updated `Add-vRLIGroup` cmdlet usage and Active Directory support.
-- Enhanced `New-WSADeployment` cmdlet to better handle checking for and reporting a missing Cross-Instance Datacenter.
-- Enhanced `New-WSADeployment` cmdlet to check for the existence of a load balancer in VMware Aria Suite Lifecycle and if missing create it.
+- Enhanced `New-WSADeployment` cmdlet:
+  - better handle checking for and reporting a missing Cross-Instance Datacenter.
+  - check for the existence of a load balancer in VMware Aria Suite Lifecycle and if missing create it.
 - Enhanced `New-vROPSDeployment` cmdlet to check for the existence of the a load balancer in VMware Aria Suite Lifecycle and if missing create it.
 - Enhanced `New-vRADeployment` cmdlet to check for the existence of the a load balancer in VMware Aria Suite Lifecycle and if missing create it.
 - Enhanced `Get-WSAServerDetails` cmdlet to include credentials and node count for the VCF-Aware Workspace ONE Access instance.
+- Enhanced `Export-vRLIJsonSpec` cmdlet to support automatic creation of anti-affinity rule.
 
 ## v2.7.1
 
@@ -102,12 +107,12 @@
   - support automatic creation of anti-affinity rule.
 - Enhanced `New-vRLIDeployment` to support deployment of VMware Aria Operations for Logs OVA using vSphere Content Library.
 - Enhanced `Export-vRAJsonSpec` cmdlet:
-  - to support VMware Cloud Foundation v5.1.0 and VMware Aria Automation v8.14.0.
-  - to support deployment of VMware Aria Automation OVA using vSphere Content Library.
+  - support VMware Cloud Foundation v5.1.0 and VMware Aria Automation v8.14.0.
+  - support deployment of VMware Aria Automation OVA using vSphere Content Library.
 - Enhanced `Export-VraJsonSpec` to support deployment of VMware Aria Automation OVA using vSphere Content Library.
 - Enhanced `Export-WsaJsonSpec` cmdlet:
-  - to support VMware Cloud Foundation v5.1.0 and Workspace ONE Access v3.3.7.
-  - to support deployment of Workspace ONE Access OVA using vSphere Content Library.
+  - support VMware Cloud Foundation v5.1.0 and Workspace ONE Access v3.3.7.
+  - support deployment of Workspace ONE Access OVA using vSphere Content Library.
 - Enhanced `New-WsaDeployment` to support deployment of Workspace ONE Access OVA using vSphere Content Library.
 - Enhanced `Install-vRLIPhotonAgent` cmdlet to support VMware Aria Operations for Logs agent configuration.
 - Enhanced `Add-vCenterGlobalPermission` cmdlet and examples with domainBindUser and domainBindUsePass as optional parameters for a local domain (_e.g._, `vsphere.local`) user.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.8.0.1013'
+    ModuleVersion = '2.8.0.1014'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -25993,6 +25993,33 @@ Function Add-vRSLCMDatacenterVcenter {
 }
 Export-ModuleMember -Function Add-vRSLCMDatacenterVcenter
 
+Function Sync-vRSLCMDatacenterVcenter {
+    <#
+        .SYNOPSIS
+        Trigger a vCenter Server inventory sync in VMware Aria Suite Lifecycle
+
+        .DESCRIPTION
+        The Sync-vRSLCMDatacenterVcenter cmdlet triggers a vCenter Server inventory sync VMware Aria Suite Lifecycle
+
+        .EXAMPLE
+        Sync-vRSLCMDatacenterVcenter -datacenterVmid <datacenter_vmid> -vcenterName <vcenter_name>
+        This example triggers a vCenter Server inventory sync
+    #>
+
+    Param (
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$datacenterVmid,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$vcenterName
+    )
+
+    Try {
+        $uri = "https://$vrslcmAppliance/lcm/lcops/api/v2/datacenters/$datacenterVmid/vcenters/$vcenterName/data-collection"
+        Invoke-RestMethod $uri -Method 'POST' -Headers $vrslcmHeaders
+    } Catch {
+        Write-Error $_.Exception.Message
+    }
+}
+Export-ModuleMember -Function Sync-vRSLCMDatacenterVcenter
+
 Function Get-vRSLCMEnvironment {
     <#
         .SYNOPSIS
@@ -26092,7 +26119,6 @@ Function Remove-vRSLCMEnvironment {
     }
 }
 Export-ModuleMember -Function Remove-vRSLCMEnvironment
-
 
 Function Get-vRSLCMLoadbalancer {
     <#
@@ -27203,6 +27229,55 @@ Function Register-vRSLCMProductBinary {
     }
 }
 Export-ModuleMember -Function Register-vRSLCMProductBinary
+
+Function Get-vRSLCMSshStatus {
+    <#
+        .SYNOPSIS
+        Get the status of the SSH service in VMware Aria Suite Lifecycle
+
+        .DESCRIPTION
+        The Get-vRSLCMSshStatus cmdlet gets the status of the SSH Server in VMware Aria Suite Lifecycle
+
+        .EXAMPLE
+        Get-vRSLCMSshStatus
+        This example gets the SSH services
+    #>
+
+    Try {
+        $uri = "https://$vrslcmAppliance/lcm/lcops/api/v2/settings/ssh"
+        Invoke-RestMethod $uri -Method 'GET' -Headers $vrslcmHeaders
+    } Catch {
+        Write-Error $_.Exception.Message
+    }
+}
+Export-ModuleMember -Function Get-vRSLCMSshStatus
+
+Function Set-vRSLCMSshStatus {
+    <#
+        .SYNOPSIS
+        Set the status of the SSH service in VMware Aria Suite Lifecycle
+
+        .DESCRIPTION
+        The Set-vRSLCMSshStatus cmdlet sets the status of the SSH Server in VMware Aria Suite Lifecycle
+
+        .EXAMPLE
+        Set-vRSLCMSshStatus -enabled false
+        This example disables the SSH services
+    #>
+
+    Param (
+        [Parameter (Mandatory = $true)] [ValidateSet('true','false')] [String]$enabled
+    )
+
+    Try {
+        $uri = "https://$vrslcmAppliance/lcm/lcops/api/v2/settings/ssh"
+        $body = '{"sshStatus": "'+ $enabled +'"}'
+        Invoke-RestMethod $uri -Method 'POST' -Headers $vrslcmHeaders -Body $body
+    } Catch {
+        Write-Error $_.Exception.Message
+    }
+}
+Export-ModuleMember -Function Set-vRSLCMSshStatus
 
 #EndRegion  End VMware Aria Suite Lifecycle Functions                        ######
 ###################################################################################


### PR DESCRIPTION
### Summary

- Added `Sync-vRSLCMDatacenterVcenter` cmdlet to trigger a data collection of a vCenter Server in VMware Aria Suite Lifecycle.
- Added `Get-vRSLCMSshStatus` cmdlet to retrieve the status of the SSH service for VMware Aria Suite Lifecycle.
- Added `Set-vRSLCMSshStatus` cmdlet to disable or enable the SSH service for VMware Aria Suite Lifecycle.

### Type

- [ ] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

### Test and Documentation

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

N/A

### Additional Information

N/A
