### PR TITLE
feat: add/remove nsxt principal identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@
 - Added `Undo-AslcmDeployment` cmdlet to remove VMware Aria Suite Lifecycle from SDDC Manager.
 - Added `Export-AslcmJsonSpec` cmdlet to generate a JSON specification file for VMware Aria Suite Lifecycle.
 - Added `Invoke-AslcmDeployment` cmdlet to perform an end-to-end install of VMware Aria Suite Lifecycle.
+- Added `Add-NsxtPrincipalIdentity` cmdlet to add a certificate based principal identity to NSX Manager.
+- Added `Undo-NsxtPrincipalIdentity` cmdlet to remove a certificate based principal identity from NSX Manager.
 - Fixed `Undo-SddcManagerRole` cmdlet where a blank line is returned due to no API response data.
 - Fixed `Undo-WorkspaceOneNsxtIntegration` cmdlet for a typo in the post validation message.
 - Fixed `Undo-NsxtVimRole` cmdlet where a blank line is returned due to no API response data.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.8.0.1034'
+    ModuleVersion = '2.8.0.1035'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
### Summary

- Added `Add-NsxtPrincipalIdentity` cmdlet to add a certificate based principal identity to NSX Manager.
- Added `Undo-NsxtPrincipalIdentity` cmdlet to remove a certificate based principal identity from NSX Manager.

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

<img width="1546" alt="image" src="https://github.com/vmware/power-validated-solutions-for-cloud-foundation/assets/31245616/24637ab4-90aa-467e-af6e-05c5b1529bed">

### Issue References

N/A

### Additional Information

N/A
