### PR TITLE
docs: documentation updates

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
-mkdocs-git-authors-plugin>=0.7.2
-mkdocs-git-revision-date-localized-plugin>=1.2.0
+mkdocs-git-revision-date-localized-plugin>=1.2.2
 mkdocs-markdownextradata-plugin>=0.2.5
-mkdocs-minify-plugin>=0.7.1
-mkdocs-open-in-new-tab>=1.0.2
+mkdocs-minify-plugin>=0.7.2
+mkdocs-open-in-new-tab>=1.0.3

--- a/docs/snippets/install-module.ps1
+++ b/docs/snippets/install-module.ps1
@@ -3,4 +3,4 @@ Install-Module -Name VMware.PowerCLI -MinimumVersion 13.1.0 -Repository PSGaller
 Install-Module -Name VMware.vSphere.SsoAdmin -MinimumVersion 1.3.9 -Repository PSGallery
 Install-Module -Name PowerVCF -MinimumVersion 2.4.0 -Repository PSGallery
 Install-Module -Name ImportExcel -MinimumVersion 7.8.5 -Repository PSGallery
-Install-Module -Name PowerValidatedSolutions -MinimumVersion 2.7.0 -Repository PSGallery
+Install-Module -Name PowerValidatedSolutions -MinimumVersion 2.8.0 -Repository PSGallery

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,6 @@ plugins:
     jinja_options:
       variable_start_string: "${{"
       variable_end_string: "}}"
-- git-authors
 - git-revision-date-localized:
     enabled: !ENV [CI, false]
     enable_creation_date: false
@@ -145,6 +144,7 @@ nav:
       - documentation/functions/aria-suite/aria-automation/Export-vRAJsonSpec.md
       - documentation/functions/aria-suite/aria-automation/Get-CloudProxy.md
       - documentation/functions/aria-suite/aria-automation/Get-CloudProxyOtk.md
+      - documentation/functions/aria-suite/aria-automation/Get-vRAAPIVersion.md
       - documentation/functions/aria-suite/aria-automation/Get-vRACloudAccount.md
       - documentation/functions/aria-suite/aria-automation/Get-vRACloudZone.md
       - documentation/functions/aria-suite/aria-automation/Get-vRAGroup.md
@@ -175,6 +175,7 @@ nav:
       - documentation/functions/aria-suite/aria-automation/Remove-vRAUserOrgRole.md
       - documentation/functions/aria-suite/aria-automation/Remove-vRAUserServiceRole.md
       - documentation/functions/aria-suite/aria-automation/Remove-vRAvRLIConfig.md
+      - documentation/functions/aria-suite/aria-automation/Request-vRAToken.md
       - documentation/functions/aria-suite/aria-automation/Set-vRADnsConfig.md
       - documentation/functions/aria-suite/aria-automation/Set-vRAGroupOrgRole.md
       - documentation/functions/aria-suite/aria-automation/Set-vRAGroupServiceRole.md
@@ -409,12 +410,14 @@ nav:
       - documentation/functions/aria-suite/aria-suite-lifecycle/Remove-vRSLCMLockerPassword.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Remove-vRSLCMMyVmwareAccount.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Remove-vRSLCMProductNtpServer.md
+      - documentation/functions/aria-suite/aria-suite-lifecycle/Remove-vRSLCMRequest.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Request-vRSLCMProductBinary.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Request-vRSLCMToken.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Resume-vRSLCMRequest.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Set-vRSLCMApplianceNtpConfig.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Set-vRSLCMDnsConfig.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Start-vRSLCMProductNode.md
+      - documentation/functions/aria-suite/aria-suite-lifecycle/Stop-vRSLCMProductNode.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Test-vRSLCMAuthentication.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Test-vRSLCMConnection.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Undo-vRSLCMDatacenter.md
@@ -446,6 +449,7 @@ nav:
       - documentation/functions/nsx/Get-NsxtBackupHistory.md
       - documentation/functions/nsx/Get-NsxtCertificate.md
       - documentation/functions/nsx/Get-NsxtComputeManager.md
+      - documentation/functions/nsx/Get-NsxtComputeManagerStatus.md
       - documentation/functions/nsx/Get-NsxtEdgeCluster.md
       - documentation/functions/nsx/Get-NsxtEdgeNode.md
       - documentation/functions/nsx/Get-NsxtEdgeNodeAuthPolicy.md
@@ -510,6 +514,7 @@ nav:
       - documentation/functions/nsx/Remove-NsxtSecurityPolicy.md
       - documentation/functions/nsx/Remove-NsxtSegment.md
       - documentation/functions/nsx/Remove-NsxtSyslogExporter.md
+      - documentation/functions/nsx/Request-NsxtToken.md
       - documentation/functions/nsx/Set-NsxtApplianceUserExpirationPolicy.md
       - documentation/functions/nsx/Set-NsxtApplianceUserPassword.md
       - documentation/functions/nsx/Set-NsxtCertificate.md
@@ -529,6 +534,7 @@ nav:
       - documentation/functions/nsx/Undo-NsxtIdentitySource.md
       - documentation/functions/nsx/Undo-NsxtLdapRole.md
       - documentation/functions/nsx/Undo-NsxtNodeProfileSyslogExporter.md
+      - documentation/functions/nsx/Undo-RouteMap.md
       - documentation/functions/nsx/Undo-NsxtVidmRole.md
       - documentation/functions/nsx/Undo-PrefixList.md
     - SDDC Manager:
@@ -610,6 +616,7 @@ nav:
       - documentation/functions/vsphere/Get-VMOvfProperty.md
       - documentation/functions/vsphere/Get-VMvAppConfig.md
       - documentation/functions/vsphere/Get-VsanHealthTest.md
+      - documentation/functions/vsphere/Install-VamiCertificate.md
       - documentation/functions/vsphere/Invoke-VcenterCommand.md
       - documentation/functions/vsphere/Move-VMtoFolder.md
       - documentation/functions/vsphere/New-VcLicense.md
@@ -669,6 +676,7 @@ nav:
       - documentation/functions/vsphere-replication/Get-VrmsTask.md
       - documentation/functions/vsphere-replication/Get-VrmsVamiCertificate.md
       - documentation/functions/vsphere-replication/Install-vSphereReplicationManager.md
+      - documentation/functions/vsphere-replication/Remove-VrmsConfiguration.md
       - documentation/functions/vsphere-replication/Request-VrmsToken.md
       - documentation/functions/vsphere-replication/Set-VrmsApplianceState.md
       - documentation/functions/vsphere-replication/Set-VrmsConfiguration.md
@@ -698,6 +706,7 @@ nav:
       - documentation/functions/vsphere-tanzu/Get-TanzuKubernetesCluster.md
       - documentation/functions/vsphere-tanzu/Get-SubscribedLibrary.md
       - documentation/functions/vsphere-tanzu/Get-VMClass.md
+      - documentation/functions/vsphere-tanzu/Get-WMLicenseStatus.md
       - documentation/functions/vsphere-tanzu/Get-WMRegistry.md
       - documentation/functions/vsphere-tanzu/Get-WMRegistryHealth.md
       - documentation/functions/vsphere-tanzu/Install-SupervisorClusterCertificate.md
@@ -707,6 +716,8 @@ nav:
       - documentation/functions/vsphere-tanzu/Remove-WMRegistry.md
       - documentation/functions/vsphere-tanzu/Request-WMClusterCSR.md
       - documentation/functions/vsphere-tanzu/Test-WMSubnetInput.md
+      - documentation/functions/vsphere-tanzu/Undo-Namespace.md
+      - documentation/functions/vsphere-tanzu/Undo-NamespacePermission.md
       - documentation/functions/vsphere-tanzu/Undo-Registry.md
       - documentation/functions/vsphere-tanzu/Undo-SupervisorCluster.md
       - documentation/functions/vsphere-tanzu/Undo-TanzuKubernetesCluster.md
@@ -740,6 +751,7 @@ nav:
       - documentation/functions/workspace-one-access/Get-WSAUser.md
       - documentation/functions/workspace-one-access/Initialize-WorkspaceOne.md
       - documentation/functions/workspace-one-access/Install-WorkspaceOne.md
+      - documentation/functions/workspace-one-access/Install-WorkspaceOneCertificate.md
       - documentation/functions/workspace-one-access/Request-WSAToken.md
       - documentation/functions/workspace-one-access/Set-WorkspaceOneApplianceNtpConfig.md
       - documentation/functions/workspace-one-access/Set-WorkspaceOneDnsConfig.md


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    In order to have the best experience with our community, we recommend that you read the code of conduct and contributing guidelines before submitting a pull request.
    
    By submitting this pull request, you confirm that you have read, understood, and agreed to the project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.
    For more information, please refer to https://www.conventionalcommits.org.
-->

### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->

- Updates installation documentation for the v2.8.0 release.
- Updates the MkDocs plugin requirements.
- Updates the MkDocs configuration to include missing functions.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [x] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

```console
power-validated-solutions-for-cloud-foundation on  docs/update-documentation 
➜ make docs-install   
pip install mkdocs-material
Collecting mkdocs-material
  Using cached mkdocs_material-9.5.3-py3-none-any.whl.metadata (16 kB)
Requirement already satisfied: babel~=2.10 in /usr/local/lib/python3.11/site-packages (from mkdocs-material) (2.12.1)
Requirement already satisfied: colorama~=0.4 in /usr/local/lib/python3.11/site-packages (from mkdocs-material) (0.4.6)
Requirement already satisfied: jinja2~=3.0 in /usr/local/lib/python3.11/site-packages (from mkdocs-material) (3.1.2)
Requirement already satisfied: markdown~=3.2 in /usr/local/lib/python3.11/site-packages (from mkdocs-material) (3.5.2)
Requirement already satisfied: mkdocs-material-extensions~=1.3 in /usr/local/lib/python3.11/site-packages (from mkdocs-material) (1.3.1)
Collecting mkdocs~=1.5.3 (from mkdocs-material)
  Using cached mkdocs-1.5.3-py3-none-any.whl.metadata (6.2 kB)
Requirement already satisfied: paginate~=0.5 in /usr/local/lib/python3.11/site-packages (from mkdocs-material) (0.5.6)
Requirement already satisfied: pygments~=2.16 in /usr/local/lib/python3.11/site-packages (from mkdocs-material) (2.17.2)
Requirement already satisfied: pymdown-extensions~=10.2 in /usr/local/lib/python3.11/site-packages (from mkdocs-material) (10.5)
Requirement already satisfied: regex>=2022.4 in /usr/local/lib/python3.11/site-packages (from mkdocs-material) (2023.10.3)
Requirement already satisfied: requests~=2.26 in /usr/local/lib/python3.11/site-packages (from mkdocs-material) (2.31.0)
Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.11/site-packages (from jinja2~=3.0->mkdocs-material) (2.1.3)
Requirement already satisfied: click>=7.0 in /usr/local/lib/python3.11/site-packages (from mkdocs~=1.5.3->mkdocs-material) (8.1.7)
Requirement already satisfied: ghp-import>=1.0 in /usr/local/lib/python3.11/site-packages (from mkdocs~=1.5.3->mkdocs-material) (2.1.0)
Requirement already satisfied: mergedeep>=1.3.4 in /usr/local/lib/python3.11/site-packages (from mkdocs~=1.5.3->mkdocs-material) (1.3.4)
Requirement already satisfied: packaging>=20.5 in /usr/local/lib/python3.11/site-packages (from mkdocs~=1.5.3->mkdocs-material) (23.2)
Requirement already satisfied: pathspec>=0.11.1 in /usr/local/lib/python3.11/site-packages (from mkdocs~=1.5.3->mkdocs-material) (0.12.1)
Requirement already satisfied: platformdirs>=2.2.0 in /usr/local/lib/python3.11/site-packages (from mkdocs~=1.5.3->mkdocs-material) (4.1.0)
Requirement already satisfied: pyyaml-env-tag>=0.1 in /usr/local/lib/python3.11/site-packages (from mkdocs~=1.5.3->mkdocs-material) (0.1)
Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.11/site-packages (from mkdocs~=1.5.3->mkdocs-material) (6.0.1)
Requirement already satisfied: watchdog>=2.0 in /usr/local/lib/python3.11/site-packages (from mkdocs~=1.5.3->mkdocs-material) (3.0.0)
Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.11/site-packages (from requests~=2.26->mkdocs-material) (3.3.2)
Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.11/site-packages (from requests~=2.26->mkdocs-material) (3.6)
Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.11/site-packages (from requests~=2.26->mkdocs-material) (2.1.0)
Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.11/site-packages (from requests~=2.26->mkdocs-material) (2023.11.17)
Requirement already satisfied: python-dateutil>=2.8.1 in /usr/local/lib/python3.11/site-packages (from ghp-import>=1.0->mkdocs~=1.5.3->mkdocs-material) (2.8.2)
Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.11/site-packages (from python-dateutil>=2.8.1->ghp-import>=1.0->mkdocs~=1.5.3->mkdocs-material) (1.16.0)
Using cached mkdocs_material-9.5.3-py3-none-any.whl (8.6 MB)
Using cached mkdocs-1.5.3-py3-none-any.whl (3.7 MB)
Installing collected packages: mkdocs, mkdocs-material
Successfully installed mkdocs-1.5.3 mkdocs-material-9.5.3
pip install --requirement docs/requirements.txt
Collecting mkdocs-git-revision-date-localized-plugin>=1.2.2 (from -r docs/requirements.txt (line 1))
  Using cached mkdocs_git_revision_date_localized_plugin-1.2.2-py3-none-any.whl.metadata (4.8 kB)
Collecting mkdocs-markdownextradata-plugin>=0.2.5 (from -r docs/requirements.txt (line 2))
  Using cached mkdocs_markdownextradata_plugin-0.2.5-py3-none-any.whl
Collecting mkdocs-minify-plugin>=0.7.2 (from -r docs/requirements.txt (line 3))
  Using cached mkdocs_minify_plugin-0.7.2-py3-none-any.whl.metadata (4.0 kB)
Collecting mkdocs-open-in-new-tab>=1.0.3 (from -r docs/requirements.txt (line 4))
  Using cached mkdocs_open_in_new_tab-1.0.3-py3-none-any.whl.metadata (5.8 kB)
Requirement already satisfied: mkdocs>=1.0 in /usr/local/lib/python3.11/site-packages (from mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (1.5.3)
Requirement already satisfied: GitPython in /usr/local/lib/python3.11/site-packages (from mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (3.1.37)
Requirement already satisfied: babel>=2.7.0 in /usr/local/lib/python3.11/site-packages (from mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (2.12.1)
Requirement already satisfied: pytz in /usr/local/lib/python3.11/site-packages (from mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (2023.3.post1)
Requirement already satisfied: pyyaml in /usr/local/lib/python3.11/site-packages (from mkdocs-markdownextradata-plugin>=0.2.5->-r docs/requirements.txt (line 2)) (6.0.1)
Requirement already satisfied: htmlmin2>=0.1.13 in /usr/local/lib/python3.11/site-packages (from mkdocs-minify-plugin>=0.7.2->-r docs/requirements.txt (line 3)) (0.1.13)
Requirement already satisfied: jsmin>=3.0.1 in /usr/local/lib/python3.11/site-packages (from mkdocs-minify-plugin>=0.7.2->-r docs/requirements.txt (line 3)) (3.0.1)
Requirement already satisfied: csscompressor>=0.9.5 in /usr/local/lib/python3.11/site-packages (from mkdocs-minify-plugin>=0.7.2->-r docs/requirements.txt (line 3)) (0.9.5)
Requirement already satisfied: click>=7.0 in /usr/local/lib/python3.11/site-packages (from mkdocs>=1.0->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (8.1.7)
Requirement already satisfied: ghp-import>=1.0 in /usr/local/lib/python3.11/site-packages (from mkdocs>=1.0->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (2.1.0)
Requirement already satisfied: jinja2>=2.11.1 in /usr/local/lib/python3.11/site-packages (from mkdocs>=1.0->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (3.1.2)
Requirement already satisfied: markdown>=3.2.1 in /usr/local/lib/python3.11/site-packages (from mkdocs>=1.0->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (3.5.2)
Requirement already satisfied: markupsafe>=2.0.1 in /usr/local/lib/python3.11/site-packages (from mkdocs>=1.0->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (2.1.3)
Requirement already satisfied: mergedeep>=1.3.4 in /usr/local/lib/python3.11/site-packages (from mkdocs>=1.0->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (1.3.4)
Requirement already satisfied: packaging>=20.5 in /usr/local/lib/python3.11/site-packages (from mkdocs>=1.0->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (23.2)
Requirement already satisfied: pathspec>=0.11.1 in /usr/local/lib/python3.11/site-packages (from mkdocs>=1.0->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (0.12.1)
Requirement already satisfied: platformdirs>=2.2.0 in /usr/local/lib/python3.11/site-packages (from mkdocs>=1.0->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (4.1.0)
Requirement already satisfied: pyyaml-env-tag>=0.1 in /usr/local/lib/python3.11/site-packages (from mkdocs>=1.0->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (0.1)
Requirement already satisfied: watchdog>=2.0 in /usr/local/lib/python3.11/site-packages (from mkdocs>=1.0->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (3.0.0)
Requirement already satisfied: gitdb<5,>=4.0.1 in /usr/local/lib/python3.11/site-packages (from GitPython->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (4.0.10)
Requirement already satisfied: python-dateutil>=2.8.1 in /usr/local/lib/python3.11/site-packages (from ghp-import>=1.0->mkdocs>=1.0->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (2.8.2)
Requirement already satisfied: smmap<6,>=3.0.1 in /usr/local/lib/python3.11/site-packages (from gitdb<5,>=4.0.1->GitPython->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (5.0.1)
Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.11/site-packages (from python-dateutil>=2.8.1->ghp-import>=1.0->mkdocs>=1.0->mkdocs-git-revision-date-localized-plugin>=1.2.2->-r docs/requirements.txt (line 1)) (1.16.0)
Using cached mkdocs_git_revision_date_localized_plugin-1.2.2-py3-none-any.whl (21 kB)
Using cached mkdocs_minify_plugin-0.7.2-py3-none-any.whl (6.5 kB)
Using cached mkdocs_open_in_new_tab-1.0.3-py3-none-any.whl (6.7 kB)
Installing collected packages: mkdocs-open-in-new-tab, mkdocs-minify-plugin, mkdocs-markdownextradata-plugin, mkdocs-git-revision-date-localized-plugin
Successfully installed mkdocs-git-revision-date-localized-plugin-1.2.2 mkdocs-markdownextradata-plugin-0.2.5 mkdocs-minify-plugin-0.7.2 mkdocs-open-in-new-tab-1.0.3

power-validated-solutions-for-cloud-foundation on  docs/update-documentation took 11.0s 
➜ make docs-serve-live
mkdocs serve --livereload -w ./
INFO    -  DeprecationWarning: warning_filter doesn't do anything since MkDocs 1.2 and will be removed soon. All messages on the `mkdocs` logger get counted automatically.
             File "/usr/local/lib/python3.11/site-packages/markdownextradata/plugin.py", line 8, in <module>
               from mkdocs.utils import warning_filter
             File "/usr/local/lib/python3.11/site-packages/mkdocs/utils/__init__.py", line 453, in __getattr__
               warnings.warn(
INFO    -  Building documentation...
INFO    -  Cleaning site directory
INFO    -  Documentation built in 27.64 seconds
INFO    -  [16:19:03] Watching paths for changes: 'docs', 'mkdocs.yml', '.'
INFO    -  [16:19:03] Serving on http://127.0.0.1:8000/power-validated-solutions-for-cloud-foundation/
```

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes' keyword followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Closes #001
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
