### PR TITLE
feat: add support for creating vcf adapter in aria operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@
 - Added `Export-HrmJsonSpec` cmdlet to generate a JSON specification file for Health Reporting and Monitoring.
 - Added `Invoke-HrmDeployment` cmdlet to perform an end-to-end deployment of Health Reporting and Monitoring.
 - Added `Invoke-UndoHrmDeployment` cmdlet to perform removal of Health Reporting and Monitoring.
+- Added `Add-vROPSAdapterVcf` cmdlet to support creating the VMware Cloud Foundation adapter in VMware Aria Operations.
 - Fixed `Invoke-IamDeployment` timing issue causing intermittent failures.
 - Fixed `Set-LocalAccountLockout` and `Get-LocalAccountLockout` to report correct data for VCF 5.1 and Photon OS 4.0.
 - Enhanced `Request-vRSLCMBundle` cmdlet to improve the progress tracking.
 - Enhanced `Get-WSAServerDetail` cmdlet to handle single node Workspace ONE Access deployments.
+- Enhanced `Invoke-IomDeployment` cmdlet to include `Add-vROPSAdapterVcf` for creating the VMware Cloud Foundation adapter in VMware Aria Operations.
 - Removed `driConfigureSupervisorCluster.ps1` from the \SampleScripts\ directory as functionality now provided using the `Invoke-DriDeployment` cmdlet.
 - Removed `driDeployTanzuCluster.ps1` from the \SampleScripts\ directory as functionality now provided using the `Invoke-DriDeployment` cmdlet.
 - Removed `driUndoDeployment.ps1` from the \SampleScripts\ directory as functionality now provided using the `Invoke-UndoDriDeployment` cmdlet.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.9.0.1010'
+    ModuleVersion = '2.9.0.1011'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/docs/documentation/functions/aria-suite/aria-operations/Add-vROPSAdapterVcf.md
+++ b/docs/documentation/functions/aria-suite/aria-operations/Add-vROPSAdapterVcf.md
@@ -1,0 +1,107 @@
+# Add-vROPSAdapterVcf
+
+## Synopsis
+
+Adds an VMware Cloud Foundation Adapter to VMware Aria Operations
+
+## Syntax
+
+``` powersehll
+Add-vROPSAdapterVcf [-server] <String> [-user] <String> [-pass] <String> [[-collectorGroupName] <String>]
+ [<CommonParameters>]
+```
+
+## Description
+
+The `Add-vROPSAdapterVcf` cmdlet adds a VMware Cloud Foundation Adapter to VMware Aria Operations.
+The cmdlet connects to SDDC Manager using the -server, -user, and -password values:
+
+- Validates that network connectivity and authentication is possible to SDDC Manager
+- Validates that VMware Aria Operations has been deployed in VCF-aware mode and retrieves its details
+- Validates that network connectivity and authentication is possible to VMware Aria Operations
+- Validates that the collector group exits in VMware Aria Operations
+- Validates that the Adapter does not already exist in VMware Aria Operations
+- Creates a new vCenter Server Adapter for each Workload Domain in the SDDC Manager instance in VMware Aria Operations
+- Creates a new vSAN Adapter for each Workload Domain in the SDDC Manager instance in VMware Aria Operations
+- Creates a new NSX Adapter for each Workload Domain in the SDDC Manager instance in VMware Aria Operations
+- Creates a new VMware Cloud Foundation Adapter in VMware Aria Operations
+- Starts the collection of the VMware Cloud Foundation Adapter in VMware Aria Operations
+
+## Examples
+
+### Example 1
+
+``` powershell
+Add-vROPSAdapterVcf -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -collectorGroupName sfo-m01-collector-group
+```
+
+This example creates a VMware Cloud Foundation adapter in VMware Aria Operations and assigns it to a collector group.
+
+## Parameters
+
+### -server
+
+The fully qualified domain name of the SDDC Manager.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -user
+
+The username to authenticate to the SDDC Manager.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -pass
+
+The password to authenticate to the SDDC Manager.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -collectorGroupName
+
+The name of the collector group from VMware Aria Operations.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: Default collector group
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/solutions/iom/index.md
+++ b/docs/documentation/functions/solutions/iom/index.md
@@ -17,7 +17,7 @@ Select an option for the solution.
 
     | Function                                                                                                       | Type                  |
     | -------------------------------------------------------------------------------------------------------------- | --------------------- |
-    | [`Export-IomJsonSpec`](Export-IomJsonSpec.md)                                                                  | End-to-End Deployment    |
+    | [`Export-IomJsonSpec`](Export-IomJsonSpec.md)                                                                  | End-to-End Deployment |
     | [`Invoke-IomDeployment`](Invoke-IomDeployment.md)                                                              | End-to-End Deployment |
     | [`Update-vRSLCMPSPack`](./../../aria-suite/aria-suite-lifecycle/Update-vRSLCMPSPack.md)                        | Procedure             |
     | [`Add-ContentLibrary`](./../../vsphere/Add-ContentLibrary.md)                                                  | Procedure             |
@@ -46,6 +46,7 @@ Select an option for the solution.
     | [`Add-vROPSVcfCredential`](./../../aria-suite/aria-operations/Add-vROPSVcfCredential.md)                       | Procedure             |
     | [`Add-vROPSVcenterCredential`](./../../aria-suite/aria-operations/Add-vROPSVcenterCredential.md)               | Procedure             |
     | [`Add-vROPSNsxCredential`](./../../aria-suite/aria-operations/Add-vROPSNsxCredential.md)                       | Procedure             |
+    | [`Add-vROPSAdapterVcf`](./../../aria-suite/aria-operations/Add-vROPSAdapterVcf.md)                             | Procedure             |
     | [`Add-vROPSAdapterPing`](./../../aria-suite/aria-operations/Add-vROPSAdapterPing.md)                           | Procedure             |
     | [`Import-vROPSNotification`](./../../aria-suite/aria-operations/Import-vROPSNotification.md)                   | Procedure             |
     | [`Add-SsoUser`](./../../vsphere/Add-SsoUser.md)                                                                | Procedure             |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -255,6 +255,7 @@ nav:
       - documentation/functions/aria-suite/aria-operations/Add-vROPSAdapterPing.md
       - documentation/functions/aria-suite/aria-operations/Add-vROPSAdapterSddcHealth.md
       - documentation/functions/aria-suite/aria-operations/Add-vROPSAdapterSrm.md
+      - documentation/functions/aria-suite/aria-operations/Add-vROPSAdapterVcf.md
       - documentation/functions/aria-suite/aria-operations/Add-vROPSAdapterVr.md
       - documentation/functions/aria-suite/aria-operations/Add-vROPSAlertPlugin.md
       - documentation/functions/aria-suite/aria-operations/Add-vROPSAlertPluginEmail.md


### PR DESCRIPTION
### Summary

- Added `Add-vROPSAdapterVcf` cmdlet to support creating the VMware Cloud Foundation adapter in VMware Aria Operations.
- Enhanced `Invoke-IomDeployment` cmdlet to include `Add-vROPSAdapterVcf` for creating the VMware Cloud Foundation adapter in VMware Aria Operations.

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [x] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

### Issue References

N/A

### Additional Information

N/A
