### PR TITLE
feat: update add-vsphererole opening default folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Enhanced `Request-vRSLCMBundle` cmdlet to improve the progress tracking.
 - Enhanced `Get-WSAServerDetail` cmdlet to handle single node Workspace ONE Access deployments.
 - Enhanced `Invoke-IomDeployment` cmdlet to include `Add-vROPSAdapterVcf` for creating the VMware Cloud Foundation adapter in VMware Aria Operations.
+- Enhanced `Add-vSphereRole` cmdlet to open by default the \vSphereRoles folder in the installed path of PowerValidatedSolutions.
 - Removed `driConfigureSupervisorCluster.ps1` from the \SampleScripts\ directory as functionality now provided using the `Invoke-DriDeployment` cmdlet.
 - Removed `driDeployTanzuCluster.ps1` from the \SampleScripts\ directory as functionality now provided using the `Invoke-DriDeployment` cmdlet.
 - Removed `driUndoDeployment.ps1` from the \SampleScripts\ directory as functionality now provided using the `Invoke-UndoDriDeployment` cmdlet.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.9.0.1011'
+    ModuleVersion = '2.9.0.1012'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -24846,7 +24846,7 @@ Function Add-vSphereRole {
         The password to authenticate to the SDDC Manager.
 
         .PARAMETER sddcDomain
-.
+        The workload domain in SDDC Manager.
 
         .PARAMETER roleName
         The name of the role to create.
@@ -24866,7 +24866,7 @@ Function Add-vSphereRole {
 
     Try {
         if (!$PsBoundParameters.ContainsKey("template")) {
-            $template = Get-ExternalFileName -title "Select the vSphere role template (.role)" -fileType "role" -location "C:\Program Files\WindowsPowerShell\Modules\PowerValidatedSolutions\vSphereRoles"
+            $template = Get-ExternalFileName -title "Select the vSphere role template (.role)" -fileType "role" -location ((Get-Module -ListAvailable -Name 'PowerValidatedSolutions' | Select-Object -First 1).ModuleBase + "\vSphereRoles")
         } else {
             if (!(Test-Path -Path $template)) {
                 Write-Error  "vSphere Role Template '$template' File Not Found"
@@ -24933,7 +24933,7 @@ Function Undo-vSphereRole {
         The password to authenticate to the SDDC Manager.
 
         .PARAMETER sddcDomain
-.
+        The workload domain in SDDC Manager.
 
         .PARAMETER roleName
         The name of the role to remove.

--- a/docs/documentation/functions/vsphere/Add-vSphereRole.md
+++ b/docs/documentation/functions/vsphere/Add-vSphereRole.md
@@ -83,7 +83,7 @@ Accept wildcard characters: False
 
 ### -sddcDomain
 
-.
+The workload domain in SDDC Manager.
 
 ```yaml
 Type: String

--- a/docs/documentation/functions/vsphere/Undo-vSphereRole.md
+++ b/docs/documentation/functions/vsphere/Undo-vSphereRole.md
@@ -83,7 +83,7 @@ Accept wildcard characters: False
 
 ### -sddcDomain
 
-The SDDC Manager domain.
+The workload domain in SDDC Manager.
 
 ```yaml
 Type: String


### PR DESCRIPTION
### Summary

- Enhanced `Add-vSphereRole` cmdlet to open by default the \vSphereRoles folder in the installed path of PowerValidatedSolutions.

### Type

- [ ] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

### Test and Documentation

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

N/A

### Additional Information

N/A
