### PR TITLE
feat: add oneclick for cbr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 - Added `Export-CbwJsonSpec` cmdlet to generate a JSON specification file for Cloud-Based Workload Protection.
 - Added `Invoke-CbwDeployment` cmdlet to perform an end-to-end deployment of Cloud-Based Workload Protection.
 - Added `Invoke-UndoCbwDeployment` cmdlet to perform removal of Cloud-Based Workload Protection.
+- Added `Export-CbrJsonSpec` cmdlet to generate a JSON specification file for Cloud-Based Ransomware Recovery.
+- Added `Invoke-CbrDeployment` cmdlet to perform an end-to-end deployment of Cloud-Based Ransomware Recovery.
+- Added `Invoke-UndoCbrDeployment` cmdlet to perform removal of Cloud-Based Ransomware Recovery.
+- Added `messageHandler` cmdlet an internal function to handle multiple lines of message output for end-to-end deployments.
 - Fixed `Invoke-IamDeployment` timing issue causing intermittent failures.
 - Fixed `Set-LocalAccountLockout` and `Get-LocalAccountLockout` to report correct data for VCF 5.1 and Photon OS 4.0.
 - Enhanced `Request-vRSLCMBundle` cmdlet to improve the progress tracking.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.9.0.1014'
+    ModuleVersion = '2.9.0.1015'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/docs/documentation/functions/solutions/cbr/Export-CbrJsonSpec.md
+++ b/docs/documentation/functions/solutions/cbr/Export-CbrJsonSpec.md
@@ -1,0 +1,67 @@
+# Export-CbrJsonSpec
+
+## Synopsis
+
+Create JSON specification for Cloud-Based Ransomware Recovery
+
+## Syntax
+
+``` powershell
+Export-CbrJsonSpec [-workbook] <String> [-jsonFile] <String> [<CommonParameters>]
+```
+
+## Description
+
+The `Export-CbrJsonSpec` cmdlet creates the JSON specification file using the Planning and Preparation
+workbook to deploy and configure Cloud-Based Ransomware Recovery:
+
+- Validates that the Planning and Preparation is available
+- Generates the JSON specification file using the Planning and Preparation workbook
+
+## Examples
+
+### Example 1
+
+``` powershell
+Export-CbrJsonSpec -workbook .\pnp-workbook.xlsx -jsonFile .\cbrDeploySpec.json
+```
+
+This example creates a JSON specification for Cloud-Based Ransomware Recovery using the Planning and Preparation Workbook.
+
+## Parameters
+
+### -workbook
+
+The path to the Planning and Preparation workbook (.xlsx) file.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -jsonFile
+
+The path to the JSON specification file to be created.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/solutions/cbr/Invoke-CbrDeployment.md
+++ b/docs/documentation/functions/solutions/cbr/Invoke-CbrDeployment.md
@@ -1,0 +1,48 @@
+# Invoke-CbrDeployment
+
+## Synopsis
+
+End-to-end Deployment of Cloud-Based Ransomware Recovery
+
+## Syntax
+
+``` powershell
+Invoke-CbrDeployment [-jsonFile] <String> [<CommonParameters>]
+```
+
+## Description
+
+The `Invoke-CbrDeployment` cmdlet is a single function to implement the configuration of the Cloud-Based
+Ransomware Recovery for VMware Cloud Foundation validated solution.
+
+## Examples
+
+### Example 1
+
+``` powershell
+Invoke-CbrDeployment -jsonFile .\cbrDeploySpec.json
+```
+
+This example configures Cloud-Based Ransomware Recovery for VMware Cloud Foundation using the JSON spec supplied.
+
+## Parameters
+
+### -jsonFile
+
+The JSON (.json) file created.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/solutions/cbr/Invoke-UndoCbrDeployment.md
+++ b/docs/documentation/functions/solutions/cbr/Invoke-UndoCbrDeployment.md
@@ -1,0 +1,48 @@
+# Invoke-UndoCbrDeployment
+
+## Synopsis
+
+End-to-end removal of Cloud-Based Ransomware Recovery
+
+## Syntax
+
+``` powershell
+Invoke-UndoCbrDeployment [-jsonFile] <String> [<CommonParameters>]
+```
+
+## Description
+
+The `Invoke-UndoCbrDeployment` cmdlet is a single function to removal the configuration of the Cloud-Based
+Ransomware Recovery for VMware Cloud Foundation validated solution.
+
+## Examples
+
+### Example 1
+
+``` powershell
+Invoke-UndoCbrDeployment -jsonFile .\cbrDeploySpec.json
+```
+
+This example removes Cloud-Based Ransomware Recovery for VMware Cloud Foundation using the JSON spec supplied.
+
+## Parameters
+
+### -jsonFile
+
+The JSON (.json) file created.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/solutions/cbr/index.md
+++ b/docs/documentation/functions/solutions/cbr/index.md
@@ -8,19 +8,23 @@ Select an option for the solution.
 
     The following functions can be use to perform the solution deployment.
 
-    | Function                                                                        | Type      |
-    | ------------------------------------------------------------------------------- | --------- |
-    | [`Add-VMFolder`](./../../vsphere/Add-VMFolder.md)                               | Procedure |
-    | [`Add-AntiAffinityRule`](./../../vsphere/Add-AntiAffinityRule.md)               | Procedure |
-    | [`Add-VmGroup`](./../../vsphere/Add-VmGroup.md)                                 | Procedure |
+    | Function                                                                        | Type                  |
+    | ------------------------------------------------------------------------------- | --------------------- |
+    | [`Export-CbrJsonSpec`](Export-CbrJsonSpec.md)                                   | End-to-End Deployment |
+    | [`Invoke-CbrDeployment`](Invoke-CbrDeployment.md)                               | End-to-End Deployment |
+    | [`Add-VMFolder`](./../../vsphere/Add-VMFolder.md)                               | Procedure             |
+    | [`Add-AntiAffinityRule`](./../../vsphere/Add-AntiAffinityRule.md)               | Procedure             |
+    | [`Add-VmGroup`](./../../vsphere/Add-VmGroup.md)                                 | Procedure             |
 
 === ":material-location-exit: &nbsp; Solution Removal"
 
     The following functions can be use to remove the solution deployment.
 
-    | Function                                                                          | Type      |
-    | --------------------------------------------------------------------------------- | --------- |
-    | [`Undo-VMFolder`](./../../vsphere/Undo-VMFolder.md)                               | Procedure |
-    | [`Undo-AntiAffinityRule`](./../../vsphere/Undo-AntiAffinityRule.md)               | Procedure |
+    | Function                                                                          | Type                |
+    | --------------------------------------------------------------------------------- | ------------------- |
+    | [`Export-CbrJsonSpec`](Export-CbrJsonSpec.md)                                     | End-to-End Removal  |
+    | [`Invoke-UndoCbrDeployment`](Invoke-UndoCbrDeployment.md)                         | End-to-End Removal  |
+    | [`Undo-VMFolder`](./../../vsphere/Undo-VMFolder.md)                               | Procedure           |
+    | [`Undo-AntiAffinityRule`](./../../vsphere/Undo-AntiAffinityRule.md)               | Procedure           |
 
 [solution]: https://docs.vmware.com/en/VMware-Cloud-Foundation/services/vcf-cloud-based-ransomware-recovery-v1/GUID-43595310-BDC8-49EA-AE68-1DD53A817781.html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -897,6 +897,10 @@ nav:
         - documentation/functions/solutions/cbw/Export-CbwJsonSpec.md
         - documentation/functions/solutions/cbw/Invoke-CbwDeployment.md
         - documentation/functions/solutions/cbw/Invoke-UndoCbwDeployment.md
+      - Cloud-Based Ransomware Recovery:
+        - documentation/functions/solutions/cbr/Export-CbrJsonSpec.md
+        - documentation/functions/solutions/cbr/Invoke-CbrDeployment.md
+        - documentation/functions/solutions/cbr/Invoke-UndoCbrDeployment.md
     - Tests:
       - documentation/functions/supporting/Test-DnsServers.md
       - documentation/functions/supporting/Test-EndpointConnection.md


### PR DESCRIPTION
### Summary

- Added `Export-CbrJsonSpec` cmdlet to generate a JSON specification file for Cloud-Based Ransomware Recovery.
- Added `Invoke-CbrDeployment` cmdlet to perform an end-to-end deployment of Cloud-Based Ransomware Recovery.
- Added `Invoke-UndoCbrDeployment` cmdlet to perform removal of Cloud-Based Ransomware Recovery.
- Added `messageHandler` cmdlet an internal function to handle multiple lines of message output for end-to-end deployments.
- Added documentation for Cloud-Based Ransomware Recovery OneClick cmdlets.
- Updated `Invoke-CbrDeployment` cmdlet to use `messageHandler`.
- Updated `Invoke-UndoCbrDeployment` cmdlet to use `messageHandler`.

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

#### Exporting the JSON

<img width="949" alt="image" src="https://github.com/vmware/power-validated-solutions-for-cloud-foundation/assets/31245616/9de0f7e4-11a4-4b45-876f-e086d9cd1461">

#### Deployment

<img width="1415" alt="image" src="https://github.com/vmware/power-validated-solutions-for-cloud-foundation/assets/31245616/05d3741a-3e89-4456-928e-03b5a4d28fa9">

#### Removal

<img width="1432" alt="image" src="https://github.com/vmware/power-validated-solutions-for-cloud-foundation/assets/31245616/35ee58a1-1e2c-4a9c-8111-77d2bed6c5ce">


### Issue References

N/A

### Additional Information

N/A
