### PR TITLE
feat: srm site pair using powercli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Added `Invoke-CcmDeployment` cmdlet to perform an end-to-end deployment of Cross Cloud Migration.
 - Added `Invoke-UndoCcmDeployment` cmdlet to perform removal of Cross Cloud Migration.
 - Added `Export-PdrJsonSpec` cmdlet to generate a JSON specification file for Site Protection and Disaster Recovery.
+- Added `Test-SrmSdkConnection` cmdlet to test the connection to a Site Recovery Manager instance for PowerCLI connectivity.
 - Fixed `Invoke-IamDeployment` timing issue causing intermittent failures.
 - Fixed `Set-LocalAccountLockout` and `Get-LocalAccountLockout` to report correct data for VCF 5.1 and Photon OS 4.0.
 - Fixed `Add-EsxiVrmsVMkernelPort` pre-validation to actually compare server count so that it skips if configured.
@@ -47,6 +48,12 @@
   - `Invoke-UndoIlaDeployment`
 - Enhanced `Move-VMtoFolder` cmdlet to check if the VM has already been moved and also handle multiple vCenter Server connections.
 - Enhanced `Install-VamiCertificate` cmdlet to check the path to the certificate files.
+- Enhanced `New-SrmSitePair` cmdlet to:
+  - use the native PowerCLI cmdlets for managing Site Recovery Manager.
+  - support using native PowerCLI cmdlets to manage vSphere Replication site pairing.
+- Enhanced `Undo-SrmSitePair` cmdlet:
+  - to use the native PowerCLI cmdlets for managing Site Recovery Manager.
+  - support using native PowerCLI cmdlets to manage the removal of vSphere Replication site pairing.
 - Removed `driConfigureSupervisorCluster.ps1` from the \SampleScripts\ directory as functionality now provided using the `Invoke-DriDeployment` cmdlet.
 - Removed `driDeployTanzuCluster.ps1` from the \SampleScripts\ directory as functionality now provided using the `Invoke-DriDeployment` cmdlet.
 - Removed `driUndoDeployment.ps1` from the \SampleScripts\ directory as functionality now provided using the `Invoke-UndoDriDeployment` cmdlet.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.9.0.1021'
+    ModuleVersion = '2.9.0.1023'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/docs/documentation/functions/site-recovery-manager/New-SrmSitePair.md
+++ b/docs/documentation/functions/site-recovery-manager/New-SrmSitePair.md
@@ -2,44 +2,40 @@
 
 ## Synopsis
 
-Create a site pair between Site Recovery Manager instances
+Create a site pair between vSphere Replication and Site Recovery Manager instances.
 
 ## Syntax
 
-```powershell
-New-SrmSitePair [-sddcManagerAFqdn] <String> [-sddcManagerAUser] <String> [-sddcManagerAPass] <String>
- [-sddcManagerBFqdn] <String> [-sddcManagerBUser] <String> [-sddcManagerBPass] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+``` powershell
+New-SrmSitePair [-sddcManagerAFqdn] <String> [-sddcManagerAUser] <String> [-sddcManagerAPass] <String> [-sddcManagerBFqdn] <String> [-sddcManagerBUser] <String> [-sddcManagerBPass] <String> [<CommonParameters>]
 ```
 
 ## Description
 
 The `New-SrmSitePair` cmdlet creates a site pair between Site Recovery Manager instances.
-The cmdlet connects to
-SDDC Manager in both the protected and recovery sites using the -sddcManagerAFqdn, -sddcManagerAUser,
--sddcManagerAPass, -sddcManagerBFqdn, -sddcManagerBUser, and -sddcManagerBPass values:
+The cmdlet connects to SDDC Manager in both the protected and recovery sites using the -sddcManagerAFqdn, -sddcManagerAUser, -sddcManagerAPass, -sddcManagerBFqdn, -sddcManagerBUser, and -sddcManagerBPass values:
 
 - Validates that network connectivity and authentication is possible to both SDDC Manager instances
 - Validates that network connectivity and authentication is possible to both vCenter Server instances
 - Validates that network connectivity and authentication are possible to both Site Recovery Manager instances
-- Create a site pair between the Site Recovery Manager instances integrated with their respective vCenter
-Server instances.
+- Creates a site pair between the vSphere Replication instances
+- Creates a site pair between the Site Recovery Manager instances
 
 ## Examples
 
 ### Example 1
 
-```powershell
+``` powershell
 New-SrmSitePair -sddcManagerAFqdn sfo-vcf01.sfo.rainpole.io -sddcManagerAUser administrator@vsphere.local -sddcManagerAPass VMw@re1 -sddcManagerBFqdn lax-vcf01.lax.rainpole.io -sddcManagerBUser administrator@vsphere.local -sddcManagerBPass VMw@re1!
 ```
 
-This example creates a site pair between Site Recovery Manager instances integrated with the management vCenter Server instance in each site.
+This example creates a site pair between vSphere Replication and Site Recovery Manager instances.
 
 ## Parameters
 
 ### -sddcManagerAFqdn
 
-The fully qualified domain name of the SDDC Manager.
-in the protected site.
+The fully qualified domain name of the SDDC Manager in the protected site.
 
 ```yaml
 Type: String
@@ -129,22 +125,6 @@ Aliases:
 
 Required: True
 Position: 6
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ProgressAction
-
-Progress Action
-
-```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: proga
-
-Required: False
-Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/documentation/functions/site-recovery-manager/Undo-SrmMapping.md
+++ b/docs/documentation/functions/site-recovery-manager/Undo-SrmMapping.md
@@ -2,36 +2,29 @@
 
 ## Synopsis
 
-Remove a mapping between objects (folder, network, or compute resource) in the protected and failover VCF
-instances in Site Recovery Manager
+Remove a mapping between objects (folder, network, or compute resource) in the protected and failover VCF instances in Site Recovery Manager.
 
 ## Syntax
 
 ```powershell
-Undo-SrmMapping [-sddcManagerAFqdn] <String> [-sddcManagerAUser] <String> [-sddcManagerAPass] <String>
- [-sddcManagerBFqdn] <String> [-sddcManagerBUser] <String> [-sddcManagerBPass] <String> [-type] <String>
- [-protected] <String> [-recovery] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Undo-SrmMapping [-sddcManagerAFqdn] <String> [-sddcManagerAUser] <String> [-sddcManagerAPass] <String> [-sddcManagerBFqdn] <String> [-sddcManagerBUser] <String> [-sddcManagerBPass] <String> [-type] <String> [-protected] <String> [-recovery] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## Description
 
-The `Undo-SrmMapping` cmdlet removes a mapping between objects (folder, network, or compute resource) in the
-protected and failover instances in Site Recovery Manager.
-The cmdlet connects to SDDC Manager using the
--server, -user, and -password values:
+The `Undo-SrmMapping` cmdlet removes a mapping between objects (folder, network, or compute resource) in the protected and failover instances in Site Recovery Manager. The cmdlet connects to SDDC Manager using the -server, -user, and -password values:
 
 - Validates that network connectivity and authentication is possible to both SDDC Manager instances
 - Validates that network connectivity and authentication is possible to both vCenter Server instances
 - Validates that network connectivity and authentication are possible to both Site Recovery Manager instances
-- Removes a mapping between objects in the protected and failover instances in Site Recovery Manager as
-defined by the -type, -protected, and -recovery parameters.
+- Removes a mapping between objects in the protected and failover instances in Site Recovery Manager as defined by the -type, -protected, and -recovery parameters.
 
 ## Examples
 
 ### Example 1
 
 ```powershell
-Undo-SrmMapping -sddcManagerAFqdn sfo-vcf01.sfo.rainpole.io -sddcManagerAUser administrator@vsphere.local -sddcManagerAPass VMw@re1 -sddcManagerBFqdn lax-vcf01.lax.rainpole.io -sddcManagerBUser administrator@vsphere.local -sddcManagerBPass VMw@re1! -type Folder -protected xint-m01-fd-vrslcm -recovery xint-m01-fd-vrslcm
+Undo-SrmMapping -sddcManagerAFqdn sfo-vcf01.sfo.rainpole.io -sddcManagerAUser administrator@vsphere.local -sddcManagerAPass VMw@re1! -sddcManagerBFqdn lax-vcf01.lax.rainpole.io -sddcManagerBUser administrator@vsphere.local -sddcManagerBPass VMw@re1! -type Folder -protected xint-m01-fd-vrslcm -recovery xint-m01-fd-vrslcm
 ```
 
 This example removes a mapping between protected site folder xint-m01-fd-vrslcm01 and recovery site folder xint-m01-fd-vrslcm01 in Site Recovery Manager.
@@ -56,8 +49,7 @@ This example removes a mapping between protected site compute resource vSphere C
 
 ### -sddcManagerAFqdn
 
-The fully qualified domain name of the SDDC Manager.
-managing the protected site.
+The fully qualified domain name of the SDDC Manager managing the protected site.
 
 ```yaml
 Type: String
@@ -105,8 +97,7 @@ Accept wildcard characters: False
 
 ### -sddcManagerBFqdn
 
-The fully qualified domain name of the SDDC Manager.
-managing the recovery site.
+The fully qualified domain name of the SDDC Manager managing the recovery site.
 
 ```yaml
 Type: String

--- a/docs/documentation/functions/site-recovery-manager/Undo-SrmSitePair.md
+++ b/docs/documentation/functions/site-recovery-manager/Undo-SrmSitePair.md
@@ -2,43 +2,40 @@
 
 ## Synopsis
 
-Removes an existing site pair between Site Recovery Manager instances
+Removes an existing site pair between Site Recovery Manager instances.
 
 ## Syntax
 
-```powershell
-Undo-SrmSitePair [-sddcManagerAFqdn] <String> [-sddcManagerAUser] <String> [-sddcManagerAPass] <String>
- [-sddcManagerBFqdn] <String> [-sddcManagerBUser] <String> [-sddcManagerBPass] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+``` powershell
+Undo-SrmSitePair [-sddcManagerAFqdn] <String> [-sddcManagerAUser] <String> [-sddcManagerAPass] <String> [-sddcManagerBFqdn] <String> [-sddcManagerBUser] <String> [-sddcManagerBPass] <String> [<CommonParameters>]
 ```
 
 ## Description
 
-The `Undo-SrmSitePair` cmdlet removes an existing site pair between Site Recovery Manager instances.
-The cmdlet connects to SDDC Manager in both the protected and recovery sites using the -sddcManagerAFqdn,
--sddcManagerAUser, -sddcManagerAPass, -sddcManagerBFqdn, -sddcManagerBUser, and -sddcManagerBPass values:
+The `Undo-SrmSitePair` cmdlet removes an existing site pair between vSphere Replication and Site Recovery Manager instances.
+TThe cmdlet connects to SDDC Manager in both the protected and recovery sites using the -sddcManagerAFqdn, -sddcManagerAUser, -sddcManagerAPass, -sddcManagerBFqdn, -sddcManagerBUser, and -sddcManagerBPass values:
 
 - Validates that network connectivity and authentication is possible to both SDDC Manager instances
 - Validates that network connectivity and authentication is possible to both vCenter Server instances
 - Validates that network connectivity and authentication are possible to both Site Recovery Manager instances
-- Removes an existing site pair between the Site Recovery Manager instances integrated with their respective
-vCenter Server instances.
+- Removes a site pair between the vSphere Replication instances
+- Removes a site pair between the Site Recovery Manager instances
 
 ## Examples
 
 ### Example 1
 
-```powershell
-Undo-SrmSitePair -sddcManagerAFqdn sfo-vcf01.sfo.rainpole.io -sddcManagerAUser administrator@vsphere.local -sddcManagerAPass VMw@re1 -sddcManagerBFqdn lax-vcf01.lax.rainpole.io -sddcManagerBUser administrator@vsphere.local -sddcManagerBPass VMw@re1!
+``` powershell
+Undo-SrmSitePair -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1!
 ```
 
-This example removes a site pair between Site Recovery Manager instances integrated with the management vCenter Server instance in each site.
+This example removes a site pair between vSphere Replication and Site Recovery Manager instances.
 
 ## Parameters
 
 ### -sddcManagerAFqdn
 
-The fully qualified domain name of the SDDC Manager.
-in the protected site.
+The fully qualified domain name of the SDDC Manager in the protected site.
 
 ```yaml
 Type: String
@@ -128,22 +125,6 @@ Aliases:
 
 Required: True
 Position: 6
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ProgressAction
-
-Progress Action
-
-```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: proga
-
-Required: False
-Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
### Summary

- Added `Test-SrmSdkConnection` cmdlet to test the connection to a Site Recovery Manager instance for PowerCLI connectivity.
- Enhanced `New-SrmSitePair` cmdlet to:
  - use the native PowerCLI cmdlets for managing Site Recovery Manager.
  - support using native PowerCLI cmdlets to manage vSphere Replication site pairing.
- Enhanced `Undo-SrmSitePair` cmdlet:
  - to use the native PowerCLI cmdlets for managing Site Recovery Manager.
  - support using native PowerCLI cmdlets to manage the removal of vSphere Replication site pairing.
- Address issues found in documentation and added new documentation.

### Type

- [ ] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

### Test and Documentation

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

N/A

### Additional Information

N/A
