### PR TITLE
fix: Get-vRLIRole not returning data correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Fixed `Invoke-IomDeployment` cmdlet to point out the correct certificate folder.
 - Fixed `Set-LocalUserPasswordExpiration` cmdlet if statement for `warnDays`.
 - Fixed `Invoke-DriDeployment` cmdlet to handle message output for error during execution of `Add-StoragePolicy`.
+- Fixed `Get-vRLIRole` cmdlet to ensure it returns data correctly from the API.
 - Enhanced `Export-vROpsJsonSpec` cmdlet to support automatic creation of anti-affinity rule for the VMware Aria Operations cluster nodes.
 - Enhanced `Request-vRSLCMBundle` cmdlet to improve the progress tracking.
 - Enhanced `Get-WSAServerDetail` cmdlet to handle single node Workspace ONE Access deployments.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule        = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.9.0.1039'
+    ModuleVersion     = '2.9.0.1040'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -45662,7 +45662,7 @@ Function Get-vRLIRole {
     Try {
         $uri = "https://$vrliAppliance/api/v1/roles"
         $response = Invoke-RestMethod -Method 'GET' -Uri $uri -Headers $vrliHeaders
-        $response.roles
+        $response
     } Catch {
         Write-Error $_.Exception.Message
     }


### PR DESCRIPTION
### Summary

- Fixed `Get-vRLIRole` cmdlet to ensure it returns data correctly from the API.

### Type

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

Closes #533 

### Additional Information

N/A
