### PR TITLE
fix: enable vrli content pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
 - Fixed `Invoke-PcaDeployment` cmdlet where the `Add-NsxtVidmRole` was used instead of `Add-NsxtLdapRole`.
 - Fixed `Invoke-PcaDeployment` cmdlet where the -vraUser value in `New-vRACloudAccount` was incorrect.
 - Fixed `Invoke-DriDeployment` cmdlet where `Add-Namespace` -server value was not pulling from the JSON file.
+- Fixed `Invoke-IlaDeployment` cmdlet to force GitHub Token from JSON to a string value.
+- Fixed `Add-IdentitySource` cmdlet to include -Server parameter to support isolated workload domains.
 - Enhanced `Export-vROpsJsonSpec` cmdlet to support automatic creation of anti-affinity rule for the VMware Aria Operations cluster nodes.
 - Enhanced `Request-vRSLCMBundle` cmdlet to improve the progress tracking.
 - Enhanced `Get-WSAServerDetail` cmdlet to handle single node Workspace ONE Access deployments.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.9.0.1049'
+    ModuleVersion = '2.9.0.1050'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
### Summary

- Fixed `Invoke-IlaDeployment` cmdlet to force GitHub Token from JSON to a string value.
- Fixed `Add-IdentitySource` cmdlet to include -Server parameter to support isolated workload domains.

### Type

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.


### Issue References

Closes #550 

### Additional Information

N/A
