### PR TITLE
feat: enhance add-nsxtidentitysourc to validate ad credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## v2.10.0
+
+> Release Date: Unreleased
+
+- Fixed `Test-ADAuthentication` cmdlet to pass failure message as an output rather than error message so it can be evaluated.
+- Enhanced `Add-NsxtIdentitySource` cmdlet to verify the Active Directory credentials are valid.
+
 ## v2.9.0
 
 > Release Date: 2024-03-26

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.9.0.1051'
+    ModuleVersion = '2.10.0.1000'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/docs/documentation/functions/nsx/Add-NsxtIdentitySource.md
+++ b/docs/documentation/functions/nsx/Add-NsxtIdentitySource.md
@@ -14,8 +14,7 @@ Add-NsxtIdentitySource [-server] <String> [-user] <String> [-pass] <String> [-sd
 
 ## Description
 
-The `Add-NsxtIdentitySource` cmdlets adds Active Directory over LDAP/LDAPS as an Identity Provider to the NSX
-Manager.
+The `Add-NsxtIdentitySource` cmdlets adds Active Directory over LDAP/LDAPS as an Identity Provider to the NSX Manager.
 The cmdlet connects to SDDC Manager using the -server, -user, and -password values:
 
 - Validates that network connectivity and authentication is possible to SDDC Manager
@@ -28,7 +27,7 @@ The cmdlet connects to SDDC Manager using the -server, -user, and -password valu
 ### Example 1
 
 ```powershell
-Add-NsxtIdentitySource -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -sddcDomain sfo-m01 -domain sfo.rainpole.io -domainBindUser svc-vsphere-ad -domainBindPass VMw@re1! -dcMachineName sfo-ad01 -baseDn "dc=sfo,dc=rainpole,dc=io" -protocol ldap
+Add-NsxtIdentitySource -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -sddcDomain sfo-m01 -domain sfo.rainpole.io -domainBindUser svc-nsx-ad -domainBindPass VMw@re1! -dcMachineName sfo-ad01 -baseDn "dc=sfo,dc=rainpole,dc=io" -protocol ldap
 ```
 
 This example adds the sfo.rainpole.io domain as an Identity Provider to NSX Manager using LDAP
@@ -36,7 +35,7 @@ This example adds the sfo.rainpole.io domain as an Identity Provider to NSX Mana
 ### Example 2
 
 ```powershell
-Add-NsxtIdentitySource -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -sddcDomain sfo-m01 -domain sfo.rainpole.io -domainBindUser svc-vsphere-ad -domainBindPass VMw@re1! -dcMachineName sfo-ad01 -baseDN "dc=sfo,dc=rainpole,dc=io" -protocol ldaps -certificate F:\certificates\Root64.cer
+Add-NsxtIdentitySource -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -sddcDomain sfo-m01 -domain sfo.rainpole.io -domainBindUser svc-nsx-ad -domainBindPass VMw@re1! -dcMachineName sfo-ad01 -baseDN "dc=sfo,dc=rainpole,dc=io" -protocol ldaps -certificate F:\certificates\Root64.cer
 ```
 
 This example adds the sfo.rainpole.io domain as an Identity Provider to NSX Manager using LDAPS.


### PR DESCRIPTION
### Summary

- Fixed `Test-ADAuthentication` cmdlet to pass failure message as an output rather than error message so it can be evaluated.
- Enhanced `Add-NsxtIdentitySource` cmdlet to verify the Active Directory credentials are valid.

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

### Issue References

Closes #558 

### Additional Information

N/A
