### PR TITLE
fix: address end-to-end deployement issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@
 - Added `Start-CbrMenu` cmdlet to load the Cloud-Based Ransomware Recovery sub-menu.
 - Added `Start-CcmMenu` cmdlet to load the Cross Cloud Mobility sub-menu.
 - Fixed `Test-ADAuthentication` cmdlet to pass failure message as an output rather than error message so it can be evaluated.
+- Fixed `Invoke-PcaDeployment` cmdlet where it was throwing errors when creating a Cluster Group when Standard Workspace ONE Access is deployed.
 - Enhanced `Add-NsxtIdentitySource` cmdlet to verify the Active Directory credentials are valid.
+- Enhanced `Invoke-UndoPcaDeployment` cmdlet to remove the VM folder for Private Cloud Automation.
+- Enhanced `Invoke-HrmDeployment` cmdlet to set the $failureDetected variable to false before starting the deployment.
 
 ## v2.9.0
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.10.0.1001'
+    ModuleVersion = '2.10.0.1002'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
### Summary

- Fixed `Invoke-PcaDeployment` cmdlet where it was throwing errors when creating a Cluster Group when Standard Workspace ONE Access is deployed.
- Enhanced `Invoke-UndoPcaDeployment` cmdlet to remove the VM folder for Private Cloud Automation.
- Enhanced `Invoke-HrmDeployment` cmdlet to set the $failureDetected variable to false before starting the deployment.
- 
### Type

- [x] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

### Test and Documentation

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

N/A

### Additional Information

N/A
