### PR TITLE
feat: add support for vrslcm role assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 - Added `Start-CbwMenu` cmdlet to load the Cloud-Based Workload Protection sub-menu.
 - Added `Start-CbrMenu` cmdlet to load the Cloud-Based Ransomware Recovery sub-menu.
 - Added `Start-CcmMenu` cmdlet to load the Cross Cloud Mobility sub-menu.
+- Added `Get-vRSLCMRole` cmdlet to retrieve a list of VMware Aria Suite Lifecycle roles.
+- Added `Get-vRSLCMGroup` cmdlet to retrieve a list of VMware Aria Suite Lifecycle group assignments.
+- Added `Add-vRSLCMGroup` cmdlet to add a group to a roles in VMware Aria Suite Lifecycle.
+- Added `Remove-vRSLCMGroup` cmdlet to remove the role assignments for a group in VMware Aria Suite Lifecycle.
+- Added `Add-vRLCMSGroupRole` cmdlet to add roles to groups in VMware Aria Suite Lifecycle.
+- Added `Undo-vRLCMSGroupRole` cmdlet to remove group roles in VMWare Aria Suite Lifecycle.
 - Fixed `Test-ADAuthentication` cmdlet to pass failure message as an output rather than error message so it can be evaluated.
 - Fixed `Invoke-PcaDeployment` cmdlet where it was throwing errors when creating a Cluster Group when Standard Workspace ONE Access is deployed.
 - Enhanced `Add-NsxtIdentitySource` cmdlet to verify the Active Directory credentials are valid.
@@ -25,6 +31,7 @@
 - Enhanced `Invoke-HrmDeployment` cmdlet to set the $failureDetected variable to false before starting the deployment.
 - Enhanced `Export-GlobalWsaJsonSpec` cmdlet to add missing items pulled from the PLanning and Preparation Workbook to support `Export-WsaJsonSpec`.
 - Enhanced `Export-WsaJsonSpec` cmdlet to generate the API based deployment JSON spec for Workspace ONE Access using VMware Aria Suite Lifecycle using the global JSON.
+- Enhanced `Invoke-GlobalWsaDeployment` cmdlet to use `Add-vRLCMSGroupRole` to configure VMware Aria Suite Lifecycle roles.
 
 ## v2.9.0
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.10.0.1003'
+    ModuleVersion = '2.10.0.1004'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Add-vRSLCMGroup.md
+++ b/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Add-vRSLCMGroup.md
@@ -1,0 +1,63 @@
+# Add-vRSLCMGroup
+
+## Synopsis
+
+Assign a group to a VMware Aria Suite Lifecycle role.
+
+## Syntax
+
+``` PowerShell
+Add-vRSLCMGroup [-group] <String> [-role] <String> [<CommonParameters>]
+```
+
+## Description
+
+The `Add-vRSLCMGroup` cmdlet assigns a group to a VMware Aria Suite Lifecycle roles.
+
+## Examples
+
+### Example 1
+
+``` PowerShell
+Add-vRSLCMGroup -group gg-vrslcm-admins -role "LCM Admin"
+```
+
+This example assigns a group to a the LCM Admin in VMware Aria Suite Lifecycle.
+
+## Parameters
+
+### -group
+
+The group to assign the VMware Aria Suite Lifecycle role to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -role
+
+The VMware Aria Suite Lifecycle role to assign (consists of LCM Admin, Content Developer, Content Release Manager, Certificate Administrator, VCF Role).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Add-vRSLCMGroupRole.md
+++ b/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Add-vRSLCMGroupRole.md
@@ -1,0 +1,115 @@
+# Add-vRSLCMGroupRole
+
+## Synopsis
+
+Assigns a group from the authentication provider with a role in VMware Aria Suite Lifecycle.
+
+## Syntax
+
+``` PowerShell
+Add-vRSLCMGroupRole [-server] <String> [-user] <String> [-pass] <String> [-group] <String> [-role] <String> [<CommonParameters>]
+```
+
+## Description
+
+The `Add-vRSLCMGroupRole` cmdlet assigns access to a group from the authentication provider.
+The cmdlet connects to SDDC Manager using the -server, -user, and -password values:
+
+- Validates that network connectivity and authentication is possible to SDDC Manager
+- Validates that VMware Aria Suite Lifecycle has been deployed in VCF-aware mode and retrieves its details
+- Validates that the group has not already been assigned access to VMware Aria Suite Lifecycle
+- Adds the group to the access control assigning the role provided in VMware Aria Suite Lifecycle
+
+## Examples
+
+### Example 1
+
+``` PowerShell
+Add-vRSLCMGroupRole -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -group gg-vrslcm-admins@sfo.rainpole.io -role 'LCM Admin'
+```
+
+This example adds the group gg-vrslcms-admins with the LCM Admin role in VMware Aria Suite Lifecycle.
+
+## Parameters
+
+### -server
+
+The fully qualified domain name of the SDDC Manager.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -user
+The username to authenticate to the SDDC Manager.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -pass
+The password to authenticate to the SDDC Manager.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -group
+
+The group name.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -role
+
+The role to assign to the group 'LCM Admin', 'Content Developer', 'Content Release Manager', 'Certificate Administrator', 'VCF Role'.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMGroup.md
+++ b/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMGroup.md
@@ -1,0 +1,54 @@
+# Get-vRSLCMGroup
+
+## Synopsis
+
+Retrieve group assignments in VMware Aria Suite Lifecycle.
+
+## Syntax
+
+``` PowerShell
+Get-vRSLCMGroup [[-providerVmid] <String>] [<CommonParameters>]
+```
+
+## Description
+
+The `Get-vRSLCMGroup` cmdlet retrieves a list of group assignments in VMware Aria Suite Lifecycle.
+
+## Examples
+
+### Example 1
+
+``` PowerShell
+Get-vRSLCMGroup
+```
+
+This example retrieves a list of VMware Aria Suite Lifecycle group assignments.
+
+### Example 2
+
+``` PowerShell
+Get-vRSLCMGroup -providerVmid 2d90903c-b753-4f52-905e-5421d11f6572
+```
+This example retrieves a list of VMware Aria Suite Lifecycle group assignments for the given identity provider.
+
+## Parameters
+
+### -providerVmid
+
+The vmid for the provider.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMRole.md
+++ b/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMRole.md
@@ -1,0 +1,25 @@
+# Get-vRSLCMRole
+
+## Synopsis
+
+Retrieve VMware Aria Suite Lifecycle roles.
+
+## Syntax
+
+``` PowerShell
+Get-vRSLCMRole
+```
+
+## Description
+
+The Get-vRSLCMRole cmdlet retrieves a list of VMware Aria Suite Lifecycle roles.
+
+## Examples
+
+### Example 1
+
+``` PowerShell
+Get-vRSLCMRole
+```
+
+This example retrieves a list of VMware Aria Suite Lifecycle roles.

--- a/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Remove-vRSLCMGroup.md
+++ b/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Remove-vRSLCMGroup.md
@@ -1,0 +1,47 @@
+# Remove-vRSLCMGroup
+
+## Synopsis
+
+Remove a group and its role assignments from VMware Aria Suite Lifecycle.
+
+## Syntax
+
+``` PowerShell
+Remove-vRSLCMGroup [-vmid] <String> [<CommonParameters>]
+```
+
+## Description
+
+The `Remove-vRSLCMGroup` cmdlet removes a group and its role assignments from VMware Aria Suite Lifecycle.
+
+## Examples
+
+### Example 1
+
+``` PowerShell
+Remove-vRSLCMGroup -vmid a3f18959-00b1-4703-a9ab-fad5de8efa84
+```
+
+This example removes a group and its role assignments from VMware Aria Suite Lifecycle.
+
+## Parameters
+
+### -vmid
+
+The unique identifier of the group in VMware Aria Sute Lifecycle.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Undo-vRSLCMGroupRole.md
+++ b/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Undo-vRSLCMGroupRole.md
@@ -1,0 +1,101 @@
+# Undo-vRSLCMGroupRole
+
+## Synopsis
+
+Removes the assignment for a group from the authentication provider with a role in VMware Aria Suite Lifecycle.
+
+## Syntax
+
+``` PowerShell
+Undo-vRSLCMGroupRole [-server] <String> [-user] <String> [-pass] <String> [-group] <String> [<CommonParameters>]
+```
+
+## Description
+
+The `Undo-vRSLCMGroupRole` cmdlet removes the assignment for a group from the authentication provider.
+The cmdlet connects to SDDC Manager using the -server, -user, and -password values:
+
+- Validates that network connectivity and authentication is possible to SDDC Manager
+- Validates that VMware Aria Suite Lifecycle has been deployed in VCF-aware mode and retrieves its details
+- Validates that the group has been assigned access to VMware Aria Suite Lifecycle
+- Removes the group assignment from VMware Aria Suite Lifecycle
+
+## Examples
+
+### EXAMPLE 1
+
+``` PowerShell
+Undo-vRSLCMGroupRole -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -group gg-vrslcm-admins@sfo.rainpole.io
+```
+
+This example removes access for the group gg-vrslcms-admins from VMware Aria Suite Lifecycle.
+
+## Parameters
+
+### -server
+
+The fully qualified domain name of the SDDC Manager.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -user
+
+The username to authenticate to the SDDC Manager.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -pass
+
+The password to authenticate to the SDDC Manager.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -group
+
+The group name.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -410,6 +410,7 @@ nav:
       - documentation/functions/aria-suite/aria-suite-lifecycle/Add-vRSLCMDatacenter.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Add-vRSLCMDatacenterVcenter.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Add-vRSLCMEnvironment.md
+      - documentation/functions/aria-suite/aria-suite-lifecycle/Add-vRSLCMGroup.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Add-vRSLCMLockerCertificate.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Add-vRSLCMLockerLicense.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Add-vRSLCMLockerPassword.md
@@ -424,6 +425,7 @@ nav:
       - documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMDatacenterVcenter.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMEnvironment.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMEnvironmentVMs.md
+      - documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMGroup.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMHealth.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMLoadbalancer.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMLockerCertificate.md
@@ -439,6 +441,7 @@ nav:
       - documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMProductVersion.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMPSPack.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMRequest.md
+      - documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMRole.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMServerDetail.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMSshStatus.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Import-vRSLCMLockerCertificate.md
@@ -456,6 +459,8 @@ nav:
       - documentation/functions/aria-suite/aria-suite-lifecycle/Register-vRSLCMProductBinary.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Remove-vRSLCMDatacenter.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Remove-vRSLCMEnvironment.md
+      - documentation/functions/aria-suite/aria-suite-lifecycle/Remove-vRSLCMGroup.md
+      - documentation/functions/aria-suite/aria-suite-lifecycle/Add-vRSLCMGroupRole.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Remove-vRSLCMLoadbalancer.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Remove-vRSLCMLockerCertificate.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Remove-vRSLCMLockerLicense.md
@@ -477,6 +482,7 @@ nav:
       - documentation/functions/aria-suite/aria-suite-lifecycle/Undo-vRSLCMDatacenter.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Undo-vRSLCMDeployment.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Undo-vRSLCMDnsConfig.md
+      - documentation/functions/aria-suite/aria-suite-lifecycle/Undo-vRSLCMGroupRole.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Undo-vRSLCMLockerCertificate.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Undo-vRSLCMLockerLicense.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Undo-vRSLCMLockerPassword.md


### PR DESCRIPTION
### Summary

- Added `Get-vRSLCMRole` cmdlet to retrieve a list of VMware Aria Suite Lifecycle roles.
- Added `Get-vRSLCMGroup` cmdlet to retrieve a list of VMware Aria Suite Lifecycle group assignments.
- Added `Add-vRSLCMGroup` cmdlet to add a group to a roles in VMware Aria Suite Lifecycle.
- Added `Remove-vRSLCMGroup` cmdlet to remove the role assignments for a group in VMware Aria Suite Lifecycle.
- Added `Add-vRLCMSGroupRole` cmdlet to add roles to groups in VMware Aria Suite Lifecycle.
- Added `Undo-vRLCMSGroupRole` cmdlet to remove group roles in VMWare Aria Suite Lifecycle.
- Enhanced `Invoke-GlobalWsaDeployment` cmdlet to use `Add-vRLCMSGroupRole` to configure VMware Aria Suite Lifecycle roles.

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

### Issue References

Closes #563 

### Additional Information

N/A
