### PR TITLE
fix: dri oneclick exiting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,10 @@
     "editor.trimAutoWhitespace": true,
     "editor.wordWrap": "off"
   },
+  "[yaml]": {
+    "editor.formatOnSave": false,
+    "editor.formatOnType": false
+  },
   "editor.bracketPairColorization.enabled": true,
   "editor.bracketPairColorization.independentColorPoolPerBracketType": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
 - Enhanced `Invoke-GeneratePrivateKeyAndCsr` cmdlet for error handling and message output.
 - Enhanced `Invoke-RequestSignedCertificate` cmdlet for error handling and message output.
 - Enhanced `Invoke-GenerateChainPem` cmdlet for error handling and message output.
+- Enhanced `Enable-Registry` cmdlet to handle clean exit of function when running vSphere 8.0.
+- Enhanced `Add-Namespace` cmdlet to handle expected missing object and not throw an error.
 
 ## v2.9.0
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.10.0.1017'
+    ModuleVersion = '2.10.0.1018'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
### Summary

- Enhanced `Enable-Registry` cmdlet to handle clean exit of function when running vSphere 8.0.
- Enhanced `Add-Namespace` cmdlet to handle expected missing object and not throw an error.

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

Closes #580 

### Additional Information

N/A
