### PR TITLE
feat: enhance backup-vmovfproperties to skip missing aria products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - Enhanced `Invoke-GenerateChainPem` cmdlet for error handling and message output.
 - Enhanced `Enable-Registry` cmdlet to handle clean exit of function when running vSphere 8.0.
 - Enhanced `Add-Namespace` cmdlet to handle expected missing object and not throw an error.
+- Enhanced `Backup-VMOvfProperties` cmdlet to check for the existing of each VMware Aria component and skip backing up the OVF settings if not present.
 
 ## v2.9.0
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.10.0.1022'
+    ModuleVersion = '2.10.0.1023'
     # Supported PSEditions
     # CompatiblePSEditions = @()
 


### PR DESCRIPTION
### Summary

- Enhanced `Backup-VMOvfProperties` cmdlet to check for the existing of each VMware Aria component and skip backing up the OVF settings if not present.

### Type

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

Closes #591 

### Additional Information

N/A
