### PR TITLE
feat: certificate management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,17 @@
 - Added `Request-vROPSMscaSignedCertificate` cmdlet to request a signed certificate from a Microsoft Certificate Authority for VMware Aria Operations.
 - Added `Request-vRAMscaSignedCertificate` cmdlet to request a signed certificate from a Microsoft Certificate Authority for VMware Aria Automation.
 - Added `New-PowerValidatedSolutionsLogFile` cmdlet to enable support for a log file when using the VMware Validated Solutions menu.
+- Added `Install-TanzuSignedCertificate` cmdlet to request and install a signed certificate for the Tanzu Supervisor Cluster.
+- Added `Invoke-GeneratePKCS12` cmdlet to generate a PKCS12 file (.pfx) to support certificate replacement of vSphere Replication and Site Recovery Manager.
+- Added `Request-VamiPKCS12Certificate` cmdlet to generate Private Key (.key), Signed Certificate (.crt) and PKCS12 file (.pfx) files for vSphere Replication and Site Recovery Manager.
+- Added `Test-SrmSdkAuthentication` cmdlet to verify authentication using the PowerCLI Sdk module for Site Recovery Manager.
 - Fixed `Test-ADAuthentication` cmdlet to pass failure message as an output rather than error message so it can be evaluated.
 - Fixed `Invoke-PcaDeployment` cmdlet where it was throwing errors when creating a Cluster Group when Standard Workspace ONE Access is deployed.
 - Fixed `Get-ADPrincipalGuid` cmdlet to handle failed credentials correctly.
 - Fixed `Invoke-IomDeployment` cmdlet where the wrong service account was being assigned a vCenter Server global permission.
 - Fixed `Invoke-GlobalWsaDeployment` cmdlet to handle single and multiple nodes when using `Add-ClusterGroup` with Workspace ONE Access.
 - Fixed `Set-vCenterPermission` cmdlet to better handle expected errors.
+- Fixed `Remove-VrmsReplication` cmdlet where it was calling an incorrect name for `Get-VrmsReplication`.
 - Enhanced `Add-NsxtIdentitySource` cmdlet to verify the Active Directory credentials are valid.
 - Enhanced `Invoke-UndoPcaDeployment` cmdlet to remove the VM folder for Private Cloud Automation.
 - Enhanced `Invoke-HrmDeployment` cmdlet to set the $failureDetected variable to false before starting the deployment.
@@ -63,7 +68,8 @@
 - Enhanced `Add-Namespace` cmdlet to handle expected missing object and not throw an error.
 - Enhanced `Backup-VMOvfProperties` cmdlet to check for the existing of each VMware Aria component and skip backing up the OVF settings if not present.
 - Enhanced `Invoke-DriDeployment` cmdlet to auto-generate the YAML file based on vSphere versions.
-- Fixed issue causing Jenkins pipelines to fail.
+- Enhanced `Undo-RecoveryPlan` cmdlet to consume the Site Recovery Manager PowerCLI cmdlets and improve error handling and message output.
+- Enhanced `Undo-ProtectionGroup` cmdlet to consume the Site Recovery Manager PowerCLI cmdlets and improve error handling and message output.
 
 ## v2.9.0
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.10.0.1025'
+    ModuleVersion = '2.10.0.1026'
     # Supported PSEditions
     # CompatiblePSEditions = @()
 

--- a/docs/documentation/functions/certificates/Invoke-GeneratePKCS12.md
+++ b/docs/documentation/functions/certificates/Invoke-GeneratePKCS12.md
@@ -1,0 +1,119 @@
+# Invoke-GeneratePKCS12
+
+## Synopsis
+
+Generate a PKCS12 (.pfx) file using OpenSSL.
+
+## Syntax
+
+```powershell
+Invoke-GeneratePKCS12 [-certificatePath] <String> [-privateKeyFile] <String> [-certificateFile] <String> [-certificatePassword] <String> [[-caChainFile] <String>] [<CommonParameters>]
+```
+
+## Description
+
+The `Invoke-GeneratePKCS12` cmdlet generates a PKCS12 (.pfx) file using OpenSSL with the supplied Private Key (.key), Signed Certificate (.crt) files.
+
+## Examples
+
+### Example 1
+
+```powershell
+Invoke-GeneratePKCS12 -certificatePath ".\certificates\" -privateKeyFile "sfo-m01-vrms01.sfo.rainpole.io.key" -certificateFile "sfo-m01-vrms01.sfo.rainpole.io.crt" -certificatePassword VMw@re1! -caChainFile "rpl-ad01.rainpole.io-rootCA.pem"
+```
+
+This example will generate a PFX file for sfo-m01-vrms01.sfo.rainpole.io including the Root Certificate Authority.
+
+### Example 2
+
+```powershell
+Invoke-GeneratePKCS12 -certificatePath ".\certificates\" -privateKeyFile "sfo-m01-vrms01.sfo.rainpole.io.key" -certificateFile "sfo-m01-vrms01.sfo.rainpole.io.crt" -certificatePassword VMw@re1!
+```
+
+This example will generate a PFX file for sfo-m01-vrms01.sfo.rainpole.io wihtou the Root Certificate Authority.
+
+## Parameters
+
+### -certificatePath
+
+The directory path to store the PKCS12 (.pfx) file and retrieve the Private Key (.key), Signed Certifciate (.crt) and Certificate Authority Chain (.pem) files from.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -privateKeyFile
+
+The private key (.key) file.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -certificateFile
+
+The certificate file (.crt) file.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -certificatePassword
+
+{{ Fill certificatePassword Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -caChainFile
+
+The certificate authority chain (.pem) file.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/site-recovery-manager/Install-VamiCertificate.md
+++ b/docs/documentation/functions/site-recovery-manager/Install-VamiCertificate.md
@@ -1,0 +1,139 @@
+# Install-VamiCertificate
+
+## Synopsis
+
+Install a new certificate for a VMware Application Management Interface (VAMI).
+
+## Syntax
+
+```powershell
+Install-VamiCertificate [-server] <String> [-user] <String> [-pass] <String> [[-certFile] <String>] [-certPassword] <String> [-solution] <String> [<CommonParameters>]
+```
+
+## Description
+
+The `Install-VamiCertificate` cmdlet allows you to replace the certificate of a VMware Application ManagementInterface (VAMI).
+Supports:
+
+- vSphere Replication appliance
+- Site Recovery Manager appliance
+
+## Examples
+
+### Example 1
+
+```powershell
+Install-VamiCertificate -server sfo-m01-vrms01.sfo.rainpole.io -user admin -pass VMw@re1! -certFile .\certificates\sfo-m01-vrms01.sfo.rainpole.io.pfx -certPassword VMw@re1! -solution VRMS
+```
+
+This example replaces the certificate for the VAMI interface of the vSphere Replication.
+
+### Example 2
+
+```powershell
+Install-VamiCertificate -server sfo-m01-srm01.sfo.rainpole.io -user admin -pass VMw@re1! -certFile .\certificates\sfo-m01-vrms01.sfo.rainpole.io.pfx -certPassword VMw@re1! -solution SRM
+```
+
+This example replaces the certificate for the VAMI interface of the Site Recovery Manager appliance.
+
+## Parameters
+
+### -server
+
+The FQDN of the vSphere Replication or Site Recovery Manager Virtual Appliance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -user
+
+The admin username of the vSphere Replication or Site Recovery Manager Virtual Appliance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -pass
+
+The admin password of the vSphere Replication or Site Recovery Manager Virtual Appliance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -certFile
+
+The path to the certificate file (.pfx).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -certPassword
+
+The password of the certificate file (.pfx).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -solution
+
+The solution to register with the vCenter Server.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/site-recovery-manager/Request-VamiPKCS12Certificate.md
+++ b/docs/documentation/functions/site-recovery-manager/Request-VamiPKCS12Certificate.md
@@ -1,0 +1,87 @@
+# Request-VamiPKCS12Certificate
+
+## Synopsis
+
+Request signed certificate in PKCS12 (.pfx) format for the VAMI Interface
+
+## Syntax
+
+```powershell
+Request-VamiPKCS12Certificate [-jsonFile] <String> [-certificates] <String> [-solution] <String> [<CommonParameters>]
+```
+
+## Description
+
+The `Request-VamiPKCS12Certificate` cmdlet requests a signed certificate in PKCS12 (.pfx) format for the VAMI Interface from a Microsoft Certificate Authority using the details from the a JSON specification file.
+
+## Examples
+
+### Exmaple 1
+
+```powershell
+Request-VamiPKCS12Certificate -jsonFile .\pdrDeploySpec.json -certificates .\certificates\ -solution VRMS
+```
+
+This example requests a signed certificate in PKCS12 (.pfx) format for a vSphere Replication appliance.
+
+### Example 2
+
+```powershell
+Request-VamiPKCS12Certificate -jsonFile .\pdrDeploySpec.json -certificates .\certificates\ -solution SRM
+```
+
+This example requests a signed certificate in PKCS12 (.pfx) format for a Site Recovery Manager.
+
+## Parameters
+
+### -jsonFile
+
+The path to the JSON specification file.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -certificates
+
+The folder containing the certificates.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -solution
+
+{{ Fill solution Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/site-recovery-manager/Test-SrmAuthenticationREST.md
+++ b/docs/documentation/functions/site-recovery-manager/Test-SrmAuthenticationREST.md
@@ -7,8 +7,7 @@
 ## Syntax
 
 ```powershell
-Test-SrmAuthenticationREST [-server] <String> [-user] <String> [-pass] <String> [[-remoteUser] <String>]
- [[-remotePass] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-SrmAuthenticationREST [-server] <String> [-user] <String> [-pass] <String> [[-remoteUser] <String>] [[-remotePass] <String>] [-ProgressAction <ActionPreference> [<CommonParameters>]
 ```
 
 ## Description
@@ -126,15 +125,3 @@ Accept wildcard characters: False
 ### CommonParameters
 
 This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
-## INPUTS
-
-### None
-
-## OUTPUTS
-
-### System.Object
-
-## NOTES
-
-## RELATED LINKS

--- a/docs/documentation/functions/site-recovery-manager/Test-SrmConnection.md
+++ b/docs/documentation/functions/site-recovery-manager/Test-SrmConnection.md
@@ -13,8 +13,7 @@ Test-SrmConnection [-server] <String> [[-port] <Int32>] [-ProgressAction <Action
 ## Description
 
 The `Test-SrmConnection` cmdlet checks the network connectivity to a Site Recovery Manager instance.
-Supports testing a connection on ports 443 (HTTPS) and 22 (SSH).
-Default: 443 (HTTPS).
+Supports testing a connection on ports 443 (HTTPS) and 22 (SSH). Default: 443 (HTTPS).
 
 ## Examples
 
@@ -27,14 +26,6 @@ Test-SrmConnection -server sfo-srm01.sfo.rainpole.io
 This example checks network connectivity with a Site Recovery Manager instance on default port, 443 (HTTPS).
 
 ### Example 2
-
-```powershell
-Test-SrmConnection -server sfo-srm01.sfo.rainpole.io -port 443
-```
-
-This example checks network connectivity with a Site Recovery Manager instance on port 443 (HTTPS). This is the default port.
-
-### Example 3
 
 ```powershell
 Test-SrmConnection -server sfo-srm01.sfo.rainpole.io -port 22
@@ -96,4 +87,4 @@ Accept wildcard characters: False
 
 ### Common Parameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/site-recovery-manager/Test-SrmSdkAuthentication.md
+++ b/docs/documentation/functions/site-recovery-manager/Test-SrmSdkAuthentication.md
@@ -1,0 +1,119 @@
+# Test-SrmSdkAuthentication
+
+## Synopsis
+
+Check authentication to a Site Recovery Manager instance.
+
+## Syntax
+
+```powershell
+Test-SrmSdkAuthentication [-server] <String> [-user] <String> [-pass] <String> [[-remoteUser] <String>] [[-remotePass] <String>] [<CommonParameters>]
+```
+
+## Description
+
+Checks the authentication to a Site Recovery Manager instance using the PowerCLI cmdlet Connect-SrmSdkServer.
+
+## Examples
+
+### Example 1
+
+```powershell
+Test-SrmSdkAuthentication -server sfo-m01-srm01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1!
+```
+
+This example checks authentication with a Site Recovery Manager instance.
+
+### Example 2
+
+```powershell
+Test-SrmSdkAuthentication -server sfo-m01-srm01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -remoteUser administrator@vsphere.local -remotePass VMw@re1!
+```
+
+This example checks authentication with a Site Recovery Manager instance and a remote Site Recovery Manager instance.
+
+## Parameters
+
+### -server
+
+The fully qualified domain name of the Site Recovery Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -user
+
+The username to authenticate to the Site Recovery Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -pass
+
+The password to authenticate to the Site Recovery Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -remoteUser
+
+The username to authenticate to the remote Site Recovery Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -remotePass
+
+The password to authenticate to the remote Site Recovery Manager instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/solutions/pdr/index.md
+++ b/docs/documentation/functions/solutions/pdr/index.md
@@ -11,6 +11,7 @@ Select an option for the solution.
     | Function                                                                                                | Type                  |
     | ------------------------------------------------------------------------------------------------------- | --------------------- |
     | [`Test-PdrPrerequisite`](Test-PdrPrerequisite.md)                                                       | Prerequisites         |
+    | [`Request-VamiPKCS12Certificate`](./../../vsphere-replication/Request-VamiPKCS12Certificate.md)         | Prerequisites         |
     | [`Export-PdrJsonSpec`](Export-PdrJsonSpec.md)                                                           | End-to-End Deployment |
     | [`Invoke-PdrDeployment`](Invoke-PdrDeployment.md)                                                       | End-to-End Deployment |
     | [`Add-VMFolder`](./../../vsphere/Add-VMFolder.md)                                                       | Procedure             |

--- a/docs/documentation/functions/vsphere-replication/Install-VamiCertificate.md
+++ b/docs/documentation/functions/vsphere-replication/Install-VamiCertificate.md
@@ -1,0 +1,139 @@
+# Install-VamiCertificate
+
+## Synopsis
+
+Install a new certificate for a VMware Application Management Interface (VAMI).
+
+## Syntax
+
+```powershell
+Install-VamiCertificate [-server] <String> [-user] <String> [-pass] <String> [[-certFile] <String>] [-certPassword] <String> [-solution] <String> [<CommonParameters>]
+```
+
+## Description
+
+The `Install-VamiCertificate` cmdlet allows you to replace the certificate of a VMware Application ManagementInterface (VAMI).
+Supports:
+
+- vSphere Replication appliance
+- Site Recovery Manager appliance
+
+## Examples
+
+### Example 1
+
+```powershell
+Install-VamiCertificate -server sfo-m01-vrms01.sfo.rainpole.io -user admin -pass VMw@re1! -certFile .\certificates\sfo-m01-vrms01.sfo.rainpole.io.pfx -certPassword VMw@re1! -solution VRMS
+```
+
+This example replaces the certificate for the VAMI interface of the vSphere Replication.
+
+### Example 2
+
+```powershell
+Install-VamiCertificate -server sfo-m01-srm01.sfo.rainpole.io -user admin -pass VMw@re1! -certFile .\certificates\sfo-m01-vrms01.sfo.rainpole.io.pfx -certPassword VMw@re1! -solution SRM
+```
+
+This example replaces the certificate for the VAMI interface of the Site Recovery Manager appliance.
+
+## Parameters
+
+### -server
+
+The FQDN of the vSphere Replication or Site Recovery Manager Virtual Appliance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -user
+
+The admin username of the vSphere Replication or Site Recovery Manager Virtual Appliance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -pass
+
+The admin password of the vSphere Replication or Site Recovery Manager Virtual Appliance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -certFile
+
+The path to the certificate file (.pfx).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -certPassword
+
+The password of the certificate file (.pfx).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -solution
+
+The solution to register with the vCenter Server.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/vsphere-replication/Request-VamiPKCS12Certificate.md
+++ b/docs/documentation/functions/vsphere-replication/Request-VamiPKCS12Certificate.md
@@ -1,0 +1,87 @@
+# Request-VamiPKCS12Certificate
+
+## Synopsis
+
+Request signed certificate in PKCS12 (.pfx) format for the VAMI Interface
+
+## Syntax
+
+```powershell
+Request-VamiPKCS12Certificate [-jsonFile] <String> [-certificates] <String> [-solution] <String> [<CommonParameters>]
+```
+
+## Description
+
+The `Request-VamiPKCS12Certificate` cmdlet requests a signed certificate in PKCS12 (.pfx) format for the VAMI Interface from a Microsoft Certificate Authority using the details from the a JSON specification file.
+
+## Examples
+
+### Exmaple 1
+
+```powershell
+Request-VamiPKCS12Certificate -jsonFile .\pdrDeploySpec.json -certificates .\certificates\ -solution VRMS
+```
+
+This example requests a signed certificate in PKCS12 (.pfx) format for a vSphere Replication appliance.
+
+### Example 2
+
+```powershell
+Request-VamiPKCS12Certificate -jsonFile .\pdrDeploySpec.json -certificates .\certificates\ -solution SRM
+```
+
+This example requests a signed certificate in PKCS12 (.pfx) format for a Site Recovery Manager.
+
+## Parameters
+
+### -jsonFile
+
+The path to the JSON specification file.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -certificates
+
+The folder containing the certificates.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -solution
+
+{{ Fill solution Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/vsphere-tanzu/Install-TanzuSignedCertificate.md
+++ b/docs/documentation/functions/vsphere-tanzu/Install-TanzuSignedCertificate.md
@@ -1,0 +1,65 @@
+# Install-TanzuSignedCertificate
+
+## Synopsis
+
+Install a Microsoft Certificate Authority Signed Certificate for the Tanzu Supervisor Cluster
+
+## Syntax
+
+```powershell
+Install-TanzuSignedCertificate [-jsonFile] <String> [-certificates] <String> [<CommonParameters>]
+```
+
+## Description
+
+The `Install-TanzuSignedCertificate` cmdlet requests a signed certificate for the Tanzu Supervisor Cluster
+from a Microsoft Certificate Authority using the details from the Developer Ready Infrastructure JSON
+specification file.
+
+## Examples
+
+### Example 1
+
+```powershell
+Install-TanzuSignedCertificate -jsonFile .\driDeploySpec.json -certificates .\certificates\
+```
+
+This example requests and installs a signed certificate for the Tanzu Supervisor Cluster
+
+## Parameters
+
+### -jsonFile
+
+The path to the JSON specification file.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -certificates
+
+The path to the folder where to store the certificate files.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -499,6 +499,7 @@ nav:
       - documentation/functions/aria-suite/aria-suite-lifecycle/Watch-vRSLCMRequest.md
     - Certificates:
       - documentation/functions/certificates/Invoke-GenerateChainPem.md
+      - documentation/functions/certificates/Invoke-GeneratePKCS12.md
       - documentation/functions/certificates/Invoke-GeneratePrivateKeyAndCsr.md
       - documentation/functions/certificates/Invoke-RequestSignedCertificate.md
       - documentation/functions/certificates/Request-SignedCertificate.md
@@ -641,12 +642,14 @@ nav:
       - documentation/functions/site-recovery-manager/Get-SrmTask.md
       - documentation/functions/site-recovery-manager/Get-SrmVamiCertificate.md
       - documentation/functions/site-recovery-manager/Install-SiteRecoveryManager.md
+      - documentation/functions/site-recovery-manager/Install-VamiCertificate.md
       - documentation/functions/site-recovery-manager/New-SrmSitePair.md
       - documentation/functions/site-recovery-manager/Remove-SrmConfiguration.md
       - documentation/functions/site-recovery-manager/Remove-SrmProtectionGroup.md
       - documentation/functions/site-recovery-manager/Remove-SrmRecoveryPlan.md
       - documentation/functions/site-recovery-manager/Request-SrmToken.md
       - documentation/functions/site-recovery-manager/Request-SrmTokenREST.md
+      - documentation/functions/site-recovery-manager/Request-VamiPKCS12Certificate.md
       - documentation/functions/site-recovery-manager/Set-RecoveryPlan.md
       - documentation/functions/site-recovery-manager/Set-SrmApplianceState.md
       - documentation/functions/site-recovery-manager/Set-SrmConfiguration.md
@@ -658,6 +661,7 @@ nav:
       - documentation/functions/site-recovery-manager/Test-SrmAuthentication.md
       - documentation/functions/site-recovery-manager/Test-SrmAuthenticationREST.md
       - documentation/functions/site-recovery-manager/Test-SrmConnection.md
+      - documentation/functions/site-recovery-manager/Test-SrmSdkAuthentication.md
       - documentation/functions/site-recovery-manager/Test-SrmVamiAuthentication.md
       - documentation/functions/site-recovery-manager/Test-SrmVamiConnection.md
       - documentation/functions/site-recovery-manager/Undo-ProtectionGroup.md
@@ -776,9 +780,11 @@ nav:
       - documentation/functions/vsphere-replication/Get-VrmsTask.md
       - documentation/functions/vsphere-replication/Get-VrmsVamiCertificate.md
       - documentation/functions/vsphere-replication/Get-VrmsVm.md
+      - documentation/functions/vsphere-replication/Install-VamiCertificate.md
       - documentation/functions/vsphere-replication/Install-vSphereReplicationManager.md
       - documentation/functions/vsphere-replication/Remove-VrmsConfiguration.md
       - documentation/functions/vsphere-replication/Remove-VrmsReplication.md
+      - documentation/functions/vsphere-replication/Request-VamiPKCS12Certificate.md
       - documentation/functions/vsphere-replication/Request-VrmsToken.md
       - documentation/functions/vsphere-replication/Request-VrmsTokenREST.md
       - documentation/functions/vsphere-replication/Set-VrmsApplianceState.md
@@ -816,6 +822,7 @@ nav:
       - documentation/functions/vsphere-tanzu/Get-WMRegistryHealth.md
       - documentation/functions/vsphere-tanzu/Install-SupervisorClusterCertificate.md
       - documentation/functions/vsphere-tanzu/New-SupervisorClusterCSR.md
+      - documentation/functions/vsphere-tanzu/Install-TanzuSignedCertificate.md
       - documentation/functions/vsphere-tanzu/New-TanzuKubernetesCluster.md
       - documentation/functions/vsphere-tanzu/Remove-TanzuKubernetesCluster.md
       - documentation/functions/vsphere-tanzu/Remove-WMRegistry.md


### PR DESCRIPTION
### Summary

- Added `Install-TanzuSignedCertificate` cmdlet to request and install a signed certificate for the Tanzu Supervisor Cluster.
- Added `Test-SrmSdkAuthentication` cmdlet to verify authentication using the PowerCLI Sdk module for Site Recovery Manager.
- Added `Invoke-GeneratePKCS12` cmdlet to generate a PKCS12 file (.pfx) to support certificate replacement of vSphere Replication and Site Recovery Manager.
- Added `Request-VamiPKCS12Certificate` cmdlet to generate Private Key (.key), Signed Certificate (.crt) and PKCS12 file (.pfx) files for vSphere Replication and Site Recovery Manager.
- Enhanced `Undo-RecoveryPlan` cmdlet to consume the Site Recovery Manager PowerCLI cmdlets and improve error handling and message output.
- Enhanced `Undo-ProtectionGroup` cmdlet to consume the Site Recovery Manager PowerCLI cmdlets and improve error handling and message output.
- Fixed `Remove-VrmsReplication` cmdlet where it was calling an incorrect name for `Get-VrmsReplication`.

### Type

- [x] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [x] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

### Issue References

Closes #596 

### Additional Information

N/A