### PR TITLE
fix: Add-SrmLicenseKey failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@
 - Fixed `Invoke-GlobalWsaDeployment` cmdlet to handle single and multiple nodes when using `Add-ClusterGroup` with Workspace ONE Access.
 - Fixed `Set-vCenterPermission` cmdlet to better handle expected errors.
 - Fixed `Remove-VrmsReplication` cmdlet where it was calling an incorrect name for `Get-VrmsReplication`.
+- Fixed `Add-SrmLicenseKey` cmdlet which was failing due to incorrect placement of `Disconnect-SrmServer` command.
+- Fixed `Undo-SrmLicenseKey` cmdlet which was not issuing a `Disconnect-SrmServer` command.
 - Enhanced `Add-NsxtIdentitySource` cmdlet to verify the Active Directory credentials are valid.
 - Enhanced `Invoke-UndoPcaDeployment` cmdlet to remove the VM folder for Private Cloud Automation.
 - Enhanced `Invoke-HrmDeployment` cmdlet to set the $failureDetected variable to false before starting the deployment.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.10.0.1027'
+    ModuleVersion = '2.10.0.1028'
     # Supported PSEditions
     # CompatiblePSEditions = @()
 


### PR DESCRIPTION
### Summary

- Fixed `Add-SrmLicenseKey` cmdlet which was failing due to incorrect placement of `Disconnect-SrmServer` command.
- Fixed `Undo-SrmLicenseKey` cmdlet which was not issuing a `Disconnect-SrmServer` command.

### Type

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

Closes #600 

### Additional Information

N/A
