### PR TITLE
fix: aria suite datacenter creation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - Fixed `Remove-VrmsReplication` cmdlet where it was calling an incorrect name for `Get-VrmsReplication`.
 - Fixed `Add-SrmLicenseKey` cmdlet which was failing due to incorrect placement of `Disconnect-SrmServer` command.
 - Fixed `Undo-SrmLicenseKey` cmdlet which was not issuing a `Disconnect-SrmServer` command.
+- Fixed `Invoke-GlobalWsaDeployment` cmdlet where an error is thrown when creating the Datacenter and vCenter Server objects for Cross-Instance.
 - Enhanced `Add-NsxtIdentitySource` cmdlet to verify the Active Directory credentials are valid.
 - Enhanced `Invoke-UndoPcaDeployment` cmdlet to remove the VM folder for Private Cloud Automation.
 - Enhanced `Invoke-HrmDeployment` cmdlet to set the $failureDetected variable to false before starting the deployment.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.10.0.1036'
+    ModuleVersion = '2.10.0.1037'
     # Supported PSEditions
     # CompatiblePSEditions = @()
 

--- a/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMDatacenter.md
+++ b/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Get-vRSLCMDatacenter.md
@@ -35,7 +35,7 @@ This example gets the details of a datacenter based on the vmid
 ### Example 3
 
 ```powershell
-Get-vRSLCMDatacenter -name sfo-m01-dc01
+Get-vRSLCMDatacenter -datacenterName sfo-m01-dc01
 ```
 
 This example gets the details of a datacenter based on the name.

--- a/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Invoke-vRSLCMUpgrade.md
+++ b/docs/documentation/functions/aria-suite/aria-suite-lifecycle/Invoke-vRSLCMUpgrade.md
@@ -1,0 +1,144 @@
+# Invoke-vRSLCMUpgrade
+
+## Synopsis
+
+Perform upgrade operations on VMware Aria Suite Lifecycle.
+
+## Syntax
+
+```powershell
+Invoke-vRSLCMUpgrade [-type] <String> [-username] <String> [-password] <String> [[-version] <String>] [-action] <String> [[-url] <String>] [<CommonParameters>]
+```
+
+## Description
+
+The `Invoke-vRSLCMUpgrade` cmdlet performs a number of upgrade related operations on VMware Aria Suite Lifecycle.
+These include checking for upgrade binares, performing pre-validaion and starting the upgrade.
+
+## Examples
+
+### Example 1
+
+```powershell
+Invoke-vRSLCMUpgrade -type CDROM -userName vcfadmin@local -password VMw@re1! -action check
+```
+
+This example checks the CDROM for an upgrade package.
+
+### Example 2
+
+```powershell
+Invoke-vRSLCMUpgrade -type CDROM -username vcfadmin@local -password VMw@re1! -action prevalidate
+```
+
+This example starts an upgrade precheck.
+
+### Example 3
+
+```powershell
+Invoke-vRSLCMUpgrade -type CDROM -username vcfadmin@local -password VMw@re1! -version "8.16.0.4" -action upgrade
+```
+
+This example starts the upgrade.
+
+## Parameters
+
+### -type
+
+The location for the upgrade ISO file (Options are CDROM, URL).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -username
+
+The VMware Aria Suite Lifecycle administrative user (e.g. vcfadmin@local).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -password
+
+The VMware Aria Suite Lifecycle administrative user.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -version
+
+The version of VMware Aria Suite Lifecycle to upgrade to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -action
+
+The operation to perform (Options are check, upgrade, prevalidate or prepare).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -url
+
+The url of the upgrade ISO if type is url.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/documentation/functions/solutions/wsa/Invoke-GlobalWsaDeployment.md
+++ b/docs/documentation/functions/solutions/wsa/Invoke-GlobalWsaDeployment.md
@@ -7,8 +7,7 @@ End-to-end Deployment of Global Workspace ONE Access
 ## Syntax
 
 ```powershell
-Invoke-GlobalWsaDeployment [-jsonFile] <String> [-workbook] <String> [-certificates] <String>
- [-binaries] <String> [-useContentLibrary] [-standard] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Invoke-GlobalWsaDeployment [-jsonFile] <String> [-workbook] <String> [-certificates] <String> [-binaries] <String> [-useContentLibrary] [-standard] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## Description

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -451,6 +451,7 @@ nav:
       - documentation/functions/aria-suite/aria-suite-lifecycle/Import-vRSLCMPSPack.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Install-vRSLCMCertificate.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/Install-vRSLCMPSPack.md
+      - documentation/functions/aria-suite/aria-suite-lifecycle/Invoke-vRSLCMUpgrade.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/New-vRSLCMAdapterOperation.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/New-vRSLCMDatacenter.md
       - documentation/functions/aria-suite/aria-suite-lifecycle/New-vRSLCMDatacenterVcenter.md


### PR DESCRIPTION
### Summary

- Fixed `Invoke-GlobalWsaDeployment` cmdlet where an error is thrown when creating the Datacenter and vCenter Server objects for Cross-Instance.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [x] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

N/A

### Additional Information

N/A
