### PR TITLE
fix: Get-vRAvRLIConfig cmdlet failing due to warning in the output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,8 @@
 - Fixed `Add-SrmLicenseKey` cmdlet which was failing due to incorrect placement of `Disconnect-SrmServer` command.
 - Fixed `Undo-SrmLicenseKey` cmdlet which was not issuing a `Disconnect-SrmServer` command.
 - Fixed `Invoke-GlobalWsaDeployment` cmdlet where an error is thrown when creating the Datacenter and vCenter Server objects for Cross-Instance.
-- Fixed `Invoke-PdrDeployment` cmdlet where expeted errors are thrown to the output making it look like a failure when in fact the task completes.
+- Fixed `Invoke-PdrDeployment` cmdlet where expected errors are thrown to the output making it look like a failure when in fact the task completes.
+- Fixed `Get-vRAvRLIConfig` cmdlet where is failed due to an OpenSSL error being returned with the data.
 - Enhanced `Add-NsxtIdentitySource` cmdlet to verify the Active Directory credentials are valid.
 - Enhanced `Invoke-UndoPcaDeployment` cmdlet to remove the VM folder for Private Cloud Automation.
 - Enhanced `Invoke-HrmDeployment` cmdlet to set the $failureDetected variable to false before starting the deployment.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.10.0.1040'
+    ModuleVersion = '2.10.0.1041'
     # Supported PSEditions
     # CompatiblePSEditions = @()
 

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -15600,7 +15600,9 @@ Function Get-vRAvRLIConfig {
                                         if (($output.ScriptOutput).Contains('No vRLI integration configured')) {
                                             Write-Output "VMware Aria Automation integration with VMware Aria Operations for Logs status 'Not Configured'"
                                         } elseif (($output.ScriptOutput).Contains('agentId')) {
-                                            $output.ScriptOutput | ConvertFrom-JSON
+                                            $jsonString = [regex]::Match($output.ScriptOutput, '\{.*\}', [System.Text.RegularExpressions.RegexOptions]::SingleLine).Value
+                                            Return $jsonString | ConvertFrom-JSON
+                                            # $output.ScriptOutput | ConvertFrom-JSON
                                         } else {
                                             Write-Error "Returning the VMware Aria Automation integration with VMware Aria Operations for Logs: POST_VALIDATION_FAILED"
                                         }


### PR DESCRIPTION
### Summary

- Fixed `Get-vRAvRLIConfig` cmdlet where is failed due to an OpenSSL error being returned with the data.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

Closes #605 

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
