### PR TITLE
fix: anti-affinity for az and workspace one access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed `Invoke-IamDeployment` and `Invoke-UndoIamDeployment` cmdlets where it was not discovering the NSX service accounts correctly.
 - Fixed `Invoke-IlaDeployment` cmdlet to configure NSX Syslog servers in the correct order after connecting VI Workload Domains.
 - Fixed `Request-IomMscaSignedCertificate` cmdlet where the data node FQDN for the SAN was not incorrect and the Cloud Proxy SANs were missing.
+- Fixed `Invoke-GlobalWsaDeployment` cmdlet to check for stretched cluster to be enabled and configure Anti-Affinity rule.
 - Enhanced `config.PowerValidatedSolutions` configuration file to include VMware Cloud Foundation 5.2 support.
 - Enhanced `Install-vRSLCMCertificate` cmdlet to perform additional checks that a Microsoft Certificate Authority is configured in SDDC Manager.
 - Enhanced `Test-PrereqApplicationVirtualNetwork` cmdlet to allow validation of either X_REGION or REGION_A networks.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.11.0.1010'
+    ModuleVersion = '2.11.0.1011'
     # Supported PSEditions
     # CompatiblePSEditions = @()
 

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -21255,12 +21255,6 @@ Function Invoke-InvDeployment {
                                         }
 
                                         if (!$failureDetected) {
-                                            Show-PowerValidatedSolutionsOutput -message "Moving the $networksProductName Appliance to the Dedicated Folder"
-                                            $StatusMsg = Move-VMtoFolder -server $jsonInput.sddcManagerFqdn -user $jsonInput.sddcManagerUser -pass $jsonInput.sddcManagerPass -domain $jsonInput.mgmtSddcDomainName -vmList $jsonInput.vmList -folder $jsonInput.vmFolder -WarningAction SilentlyContinue -ErrorAction SilentlyContinue -WarningVariable WarnMsg -ErrorVariable ErrorMsg
-                                            messageHandler -statusMessage $StatusMsg -warningMessage $WarnMsg -errorMessage $ErrorMsg; if ($ErrorMsg) { $failureDetected = $true }
-                                        }
-
-                                        if (!$failureDetected) {
                                             if ($jsonInput.stretchedCluster -eq "Include") {
                                                 Show-PowerValidatedSolutionsOutput -message "Adding the $networksProductName Appliances to the First Availability Zone VM Group"
                                                 $StatusMsg = Add-VmGroup -server $jsonInput.sddcManagerFqdn -user $jsonInput.sddcManagerUser -pass $jsonInput.sddcManagerPass -domain $jsonInput.mgmtSddcDomainName -name $jsonInput.drsGroupNameAz -vmList $jsonInput.vmList -WarningAction SilentlyContinue -ErrorAction SilentlyContinue -WarningVariable WarnMsg -ErrorVariable ErrorMsg
@@ -28420,8 +28414,14 @@ Function Invoke-GlobalWsaDeployment {
 
                                         if (!$failureDetected) {
                                             if ($jsonInput.stretchedCluster -eq "Include") {
+                                                $clusterNodes = (Get-vRSLCMProductNode -environmentName $jsonInput.environmentName -product vidm).vmName
+                                                if ($clusterNodes.Count -gt 1) {
+                                                    $vmList = $clusterNodes -join ","
+                                                } else {
+                                                    $vmList = $clusterNodes
+                                                }
                                                 Show-PowerValidatedSolutionsOutput -message "Adding the $wsaProductName Cluster Appliances to the First Availability Zone VM Group"
-                                                $StatusMsg = Add-VmGroup -server $jsonInput.sddcManagerFqdn -user $jsonInput.sddcManagerUser -pass $jsonInput.sddcManagerPass -domain $jsonInput.mgmtSddcDomainName -name $jsonInput.drsVmGroupNameAz -vmList $jsonInput.vmList -WarningAction SilentlyContinue -ErrorAction SilentlyContinue -WarningVariable WarnMsg -ErrorVariable ErrorMsg
+                                                $StatusMsg = Add-VmGroup -server $jsonInput.sddcManagerFqdn -user $jsonInput.sddcManagerUser -pass $jsonInput.sddcManagerPass -domain $jsonInput.mgmtSddcDomainName -name $jsonInput.drsVmGroupNameAz -vmList $vmList -WarningAction SilentlyContinue -ErrorAction SilentlyContinue -WarningVariable WarnMsg -ErrorVariable ErrorMsg
                                                 messageHandler -statusMessage $StatusMsg -warningMessage $WarnMsg -errorMessage $ErrorMsg; if ($ErrorMsg) { $failureDetected = $true }
                                             }
                                         }
@@ -57294,7 +57294,7 @@ Function Start-IlaMenu {
         $menuitem06 = "Remove from Environment"
 
         $headingItem03 = "Solution Interoperability"
-        $menuitem07 = "Deployment"
+        $menuitem07 = "Configuration"
         $menuitem08 = "Remove from Environment"
 
         Do {
@@ -57396,7 +57396,7 @@ Function Start-IomMenu {
         $menuitem06 = "Remove from Environment"
 
         $headingItem03 = "Solution Interoperability"
-        $menuitem07 = "Deployment"
+        $menuitem07 = "Configuration"
         $menuitem08 = "Remove from Environment"
 
         Do {
@@ -57498,7 +57498,7 @@ Function Start-InvMenu {
         $menuitem06 = "Remove from Environment"
 
         $headingItem03 = "Solution Interoperability"
-        $menuitem07 = "Deployment"
+        $menuitem07 = "Configuration"
         $menuitem08 = "Remove from Environment"
 
         Do {
@@ -57849,7 +57849,7 @@ Function Start-CbwMenu {
         $menuitem06 = "Remove from Environment"
 
         $headingItem03 = "Solution Interoperability"
-        $menuitem07 = "Deployment"
+        $menuitem07 = "Configuration"
         $menuitem08 = "Remove from Environment"
 
         Do {


### PR DESCRIPTION

<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    In order to have the best experience with our community, we recommend that you read the code of conduct and contributing guidelines before submitting a pull request.
    
    By submitting this pull request, you confirm that you have read, understood, and agreed to the project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.
    For more information, please refer to https://www.conventionalcommits.org.
-->

### Summary

- Fixed `Invoke-GlobalWsaDeployment` cmdlet to check for stretched cluster to be enabled and configure Anti-Affinity rule.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

N/A

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
