### PR TITLE
refactor: compress content pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,8 +79,9 @@
 - Enhanced `Invoke-UndoIomDeployment` cmdlet to remove the load balancer configured in VMware Aria Suite Lifecycle for VMware Aria Operations.
 - Enhanced `Invoke-UndoPcaDeployment` cmdlet to remove the load balancer configured in VMware Aria Suite Lifecycle for VMware Aria Automation.
 - Enhanced `Invoke-InvDeployment` cmdlet to add data collector and LDAP configuration functions.
-- Converted `aria-operations-notifications-vcf.csv` to 'aria-operations-notifications-vcf.json'.
-- Converted `aria-operations-notifications-srm.csv' to 'aria-operations-notifications-srm.json'.
+- Enhanced `Install-vRLIContentPack` cmdlet to compress the and stream the content pack JSON payload to VMware Aria Operations for Logs.
+- Converted `aria-operations-notifications-vcf.csv` to `aria-operations-notifications-vcf.json`.
+- Converted `aria-operations-notifications-srm.csv` to `aria-operations-notifications-srm.json`.
 
 ## v2.10.0
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -8,10 +8,10 @@
 @{
 
     # Script module or binary module file associated with this manifest.
-    RootModule = 'PowerValidatedSolutions.psm1'
+    RootModule        = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.11.0.1048'
+    ModuleVersion     = '2.11.0.1049'
 
     # ID used to uniquely identify this module
     GUID              = 'a6dfed7b-65d2-4da2-bdcc-7f3d3df9b75d'


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    In order to have the best experience with our community, we recommend that you read the code of conduct and contributing guidelines before submitting a pull request.
    
    By submitting this pull request, you confirm that you have read, understood, and agreed to the project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.
    For more information, please refer to https://www.conventionalcommits.org.
-->

### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->

Updates the content pack install/update to compress the payload with gzip.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [x] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

```powershell
PS C:\Users\Administrator> Enable-vRLIContentPack -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -token $mytoken -contentPack WSA
WARNING: Installing Content Pack (VMware Workspace ONE Access v2.2) to VMware Aria Operations for Logs (sfo-vrli01.sfo.rainpole.io), already exists: SKIPPED

PS C:\Users\Administrator> Remove-vRLIContentPack -namespace 'com.vmware.vidm'

PS C:\Users\Administrator> Enable-vRLIContentPack -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -token $mytoken -contentPack WSA
Installing content pack (VMware Workspace ONE Access v2.2) to VMware Aria Operations for Logs (sfo-vrli01.sfo.rainpole.io): SUCCESSFUL

PS C:\Users\Administrator> Remove-vRLIContentPack -namespace 'com.vmware.vsan'

PS C:\Users\Administrator> Enable-vRLIContentPack -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -token $mytoken -contentPack VSAN
Installing content pack (VMware - vSAN v3.0) to VMware Aria Operations for Logs (sfo-vrli01.sfo.rainpole.io): SUCCESSFUL
```


<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes' keyword followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Closes #001
-->

Closes #583

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
