### PR TITLE
feat: add additional value checks on pnp extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 - Enhanced `Invoke-UndoPcaDeployment` cmdlet to remove the load balancer configured in VMware Aria Suite Lifecycle for VMware Aria Automation.
 - Enhanced `Invoke-InvDeployment` cmdlet to add data collector and LDAP configuration functions.
 - Enhanced `Install-vRLIContentPack` cmdlet to compress the and stream the content pack JSON payload to VMware Aria Operations for Logs.
+- Enhanced all `Export-???JsonSpec` cmdlets to check for 'N/A', 'n/a' and '#VALUE' values extracted from the Planning and Preparation Workbook and warn.
 - Converted `aria-operations-notifications-vcf.csv` to `aria-operations-notifications-vcf.json`.
 - Converted `aria-operations-notifications-srm.csv` to `aria-operations-notifications-srm.json`.
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.11.0.1050'
+    ModuleVersion = '2.11.0.1051'
 
     # ID used to uniquely identify this module
     GUID              = 'a6dfed7b-65d2-4da2-bdcc-7f3d3df9b75d'

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -121,7 +121,7 @@ Function Export-IamJsonSpec {
             $jsonObject | ConvertTo-Json -Depth 12 | Out-File -Encoding UTF8 -FilePath $jsonFile
             $jsonInput = (Get-Content -Path $jsonFile) | ConvertFrom-Json
             Foreach ($jsonValue in $jsonInput.psobject.properties) {
-                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value ) {
+                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value -or $jsonValue.value -eq "N/A" -or $jsonValue.value -eq "N/A" -or $jsonValue.value -match "#VALUE" ) {
                     Show-PowerValidatedSolutionsOutput -type WARNING -message ('Missing value for property: {0}' -f $jsonValue.Name)
                     $issueWithJson = $true
                 }
@@ -2755,21 +2755,21 @@ Function Export-PdrJsonSpec {
                 Close-ExcelPackage $pnpRecoveryWorkbook -NoSave -ErrorAction SilentlyContinue
                 $baseData = $jsonObject | ConvertTo-Json -Depth 12; $baseData = $baseData | ConvertFrom-Json
                 Foreach ($jsonValue in $baseData.psobject.properties) {
-                    if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value ) {
+                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value -or $jsonValue.value -eq "N/A" -or $jsonValue.value -eq "N/A" -or $jsonValue.value -match "#VALUE" ) {
                         Show-PowerValidatedSolutionsOutput -type WARNING -message ('Missing value for property: {0}' -f $jsonValue.Name)
                         $issueWithJson = $true
                     }
                 }
                 $protectedData = $protectedObject | ConvertTo-Json -Depth 12; $protectedData = $protectedData | ConvertFrom-Json
                 Foreach ($objectValue in $protectedData.psobject.properties) {
-                    if ($objectValue.value -eq "Value Missing" -or $null -eq $objectValue.value ) {
+                    if ($objectValue.value -eq "Value Missing" -or $null -eq $objectValue.value -or $objectValue.value -eq "N/A" -or $objectValue.value -eq "N/A" -or $objectValue.value -match "#VALUE" ) {
                         Show-PowerValidatedSolutionsOutput -type WARNING -message ('Missing value for Protected property: {0}' -f $objectValue.Name)
                         $issueWithJson = $true
                     }
                 }
                 $recoveryData = $recoveryObject | ConvertTo-Json -Depth 12; $recoveryData = $recoveryData | ConvertFrom-Json
                 Foreach ($objectValue in $recoveryData.psobject.properties) {
-                    if ($objectValue.value -eq "Value Missing" -or $null -eq $objectValue.value ) {
+                    if ($objectValue.value -eq "Value Missing" -or $null -eq $objectValue.value -or $objectValue.value -eq "N/A" -or $objectValue.value -eq "N/A" -or $objectValue.value -match "#VALUE" ) {
                         Show-PowerValidatedSolutionsOutput -type WARNING -message ('Missing value for Recovery property: {0}' -f $objectValue.Name)
                         $issueWithJson = $true
                     }
@@ -9687,7 +9687,7 @@ Function Export-DriJsonSpec {
             $jsonObject | ConvertTo-Json -Depth 12 | Out-File -Encoding UTF8 -FilePath $jsonFile
             $jsonInput = (Get-Content -Path $jsonFile) | ConvertFrom-Json
             Foreach ($jsonValue in $jsonInput.psobject.properties) {
-                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value ) {
+                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value -or $jsonValue.value -eq "N/A" -or $jsonValue.value -eq "N/A" -or $jsonValue.value -match "#VALUE" ) {
                     Show-PowerValidatedSolutionsOutput -type WARNING -message ('Missing value for property: {0}' -f $jsonValue.Name)
                     $issueWithJson = $true
                 }
@@ -13389,7 +13389,7 @@ Function Export-IlaJsonSpec {
             $jsonObject | ConvertTo-Json -Depth 12 | Out-File -Encoding UTF8 -FilePath $jsonFile
             $jsonInput = (Get-Content -Path $jsonFile) | ConvertFrom-Json
             Foreach ($jsonValue in $jsonInput.psobject.properties) {
-                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value ) {
+                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value -or $jsonValue.value -eq "N/A" -or $jsonValue.value -eq "N/A" -or $jsonValue.value -match "#VALUE" ) {
                     Show-PowerValidatedSolutionsOutput -type WARNING -message ('Missing value for property: {0}' -f $jsonValue.Name)
                     $issueWithJson = $true
                 }
@@ -17307,7 +17307,7 @@ Function Export-IomJsonSpec {
             $jsonObject | ConvertTo-Json -Depth 12 | Out-File -Encoding UTF8 -FilePath $jsonFile
             $jsonInput = (Get-Content -Path $jsonFile) | ConvertFrom-Json
             Foreach ($jsonValue in $jsonInput.psobject.properties) {
-                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value ) {
+                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value -or $jsonValue.value -eq "N/A" -or $jsonValue.value -eq "N/A" -or $jsonValue.value -match "#VALUE" ) {
                     Show-PowerValidatedSolutionsOutput -type WARNING -message ('Missing value for property: {0}' -f $jsonValue.Name)
                     $issueWithJson = $true
                 }
@@ -23596,7 +23596,7 @@ Function Export-PcaJsonSpec {
             $jsonObject | ConvertTo-Json -Depth 12 | Out-File -Encoding UTF8 -FilePath $jsonFile
             $jsonInput = (Get-Content -Path $jsonFile) | ConvertFrom-Json
             Foreach ($jsonValue in $jsonInput.psobject.properties) {
-                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value ) {
+                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value -or $jsonValue.value -eq "N/A" -or $jsonValue.value -eq "N/A" -or $jsonValue.value -match "#VALUE" ) {
                     Show-PowerValidatedSolutionsOutput -type WARNING -message ('Missing value for property: {0}' -f $jsonValue.Name)
                     $issueWithJson = $true
                 }
@@ -26565,7 +26565,7 @@ Function Export-HrmJsonSpec {
             $jsonObject | ConvertTo-Json -Depth 12 | Out-File -Encoding UTF8 -FilePath $jsonFile
             $jsonInput = (Get-Content -Path $jsonFile) | ConvertFrom-Json
             Foreach ($jsonValue in $jsonInput.psobject.properties) {
-                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value ) {
+                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value -or $jsonValue.value -eq "N/A" -or $jsonValue.value -eq "N/A" -or $jsonValue.value -match "#VALUE" ) {
                     Show-PowerValidatedSolutionsOutput -type WARNING -message ('Missing value for property: {0}' -f $jsonValue.Name)
                     $issueWithJson = $true
                 }
@@ -27115,7 +27115,7 @@ Function Export-CbwJsonSpec {
             $jsonObject | ConvertTo-Json -Depth 12 | Out-File -Encoding UTF8 -FilePath $jsonFile
             $jsonInput = (Get-Content -Path $jsonFile) | ConvertFrom-Json
             Foreach ($jsonValue in $jsonInput.psobject.properties) {
-                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value ) {
+                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value -or $jsonValue.value -eq "N/A" -or $jsonValue.value -eq "N/A" -or $jsonValue.value -match "#VALUE" ) {
                     Show-PowerValidatedSolutionsOutput -type WARNING -message ('Missing value for property: {0}' -f $jsonValue.Name)
                     $issueWithJson = $true
                 }
@@ -27578,7 +27578,7 @@ Function Export-CbrJsonSpec {
             $jsonObject | ConvertTo-Json -Depth 12 | Out-File -Encoding UTF8 -FilePath $jsonFile
             $jsonInput = (Get-Content -Path $jsonFile) | ConvertFrom-Json
             Foreach ($jsonValue in $jsonInput.psobject.properties) {
-                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value ) {
+                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value -or $jsonValue.value -eq "N/A" -or $jsonValue.value -eq "N/A" -or $jsonValue.value -match "#VALUE" ) {
                     Show-PowerValidatedSolutionsOutput -type WARNING -message ('Missing value for property: {0}' -f $jsonValue.Name)
                     $issueWithJson = $true
                 }
@@ -27978,7 +27978,7 @@ Function Export-CcmJsonSpec {
             $jsonObject | ConvertTo-Json -Depth 12 | Out-File -Encoding UTF8 -FilePath $jsonFile
             $jsonInput = (Get-Content -Path $jsonFile) | ConvertFrom-Json
             Foreach ($jsonValue in $jsonInput.psobject.properties) {
-                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value ) {
+                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value -or $jsonValue.value -eq "N/A" -or $jsonValue.value -eq "N/A" -or $jsonValue.value -match "#VALUE" ) {
                     Show-PowerValidatedSolutionsOutput -type WARNING -message ('Missing value for property: {0}' -f $jsonValue.Name)
                     $issueWithJson = $true
                 }
@@ -28467,7 +28467,7 @@ Function Export-vRSLCMJsonSpec {
             $jsonObject | ConvertTo-Json -Depth 12 | Out-File -Encoding UTF8 -FilePath $jsonFile
             $jsonInput = (Get-Content -Path $jsonFile) | ConvertFrom-Json
             Foreach ($jsonValue in $jsonInput.psobject.properties) {
-                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value ) {
+                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value -or $jsonValue.value -eq "N/A" -or $jsonValue.value -eq "N/A" -or $jsonValue.value -match "#VALUE" ) {
                     $issueWithJson = $true
                 }
             }
@@ -30068,7 +30068,7 @@ Function Export-GlobalWsaJsonSpec {
             $jsonObject | ConvertTo-Json -Depth 12 | Out-File -Encoding UTF8 -FilePath $jsonFile
             $jsonInput = (Get-Content -Path $jsonFile) | ConvertFrom-Json
             Foreach ($jsonValue in $jsonInput.psobject.properties) {
-                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value ) {
+                if ($jsonValue.value -eq "Value Missing" -or $null -eq $jsonValue.value -or $jsonValue.value -eq "N/A" -or $jsonValue.value -eq "N/A" -or $jsonValue.value -match "#VALUE" ) {
                     $issueWithJson = $true
                 }
             }


### PR DESCRIPTION
### Summary

- Enhanced all `Export-???JsonSpec` cmdlets to check for 'N/A', 'n/a' and '#VALUE' values extracted from the Planning and Preparation Workbook and warn.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

Closes #692 

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
