### PR TITLE
fix: changed named cell for supervisor cluster

### DIFF
--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.11.0.1052'
+    ModuleVersion = '2.11.0.1053'
 
     # ID used to uniquely identify this module
     GUID              = 'a6dfed7b-65d2-4da2-bdcc-7f3d3df9b75d'

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -9650,7 +9650,7 @@ Function Export-DriJsonSpec {
                 'tagName'                       = $pnpWorkbook.Workbook.Names["k8s_vcenter_tag"].Value
                 'storagePolicyName'             = $pnpWorkbook.Workbook.Names["k8s_vcenter_storage_policy"].Value
                 'contentLibraryName'            = $pnpWorkbook.Workbook.Names["k8s_vcenter_content_library"].Value
-                'supervisorClusterName'         = $pnpWorkbook.Workbook.Names["wld_cluster"].Value
+                'supervisorClusterName'         = $pnpWorkbook.Workbook.Names["dri_vcenter_cluster"].Value
                 'supervisorClusterSizeHint'     = "Tiny"
                 'domainFqdn'                    = $pnpWorkbook.Workbook.Names["region_ad_child_fqdn"].Value
                 'domainBindUser'                = $pnpWorkbook.Workbook.Names["child_svc_vsphere_ad_user"].Value


### PR DESCRIPTION
### Summary

- Udpated `Export-DriJsonSpec` with new named cell following changes to the PnP.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes' keyword followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Closes #001
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
