### PR TITLE
fix: kubectl path in JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 > Release Date: Not Released
 
-- Enhanced `Invoke-InvDeployment` cmdlet to remove the need for Workspace ONE Acceess and add in the `admin` password to the VMware Aria Suite Lifecycke password locker.
+- Enhanced `Invoke-InvDeployment` cmdlet to remove the need for Workspace ONE Access and add in the `admin` password to the VMware Aria Suite Lifecycle password locker.
 - Enhanced `Get-LocalAccountLockout` cmdlet to handle "null" values got as "Not Configured" when appliance is not configured.
+- Enhanced `Export-DriJsonSpec` cmdlet to define the path to the Kubectl utility.
+- Enhanced `Start-DriMenu` cmdlet to use the new JSON value for the path to the Kubectl utility.
 
 ## v2.11.0
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.11.1.1001'
+    ModuleVersion = '2.11.1.1002'
 
     # ID used to uniquely identify this module
     GUID              = 'a6dfed7b-65d2-4da2-bdcc-7f3d3df9b75d'

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -9682,6 +9682,7 @@ Function Export-DriJsonSpec {
                 'namespaceViewUserGroup'        = $pnpWorkbook.Workbook.Names["group_gg_kub_readonly"].Value
                 'tanzuNamespaceName'            = $pnpWorkbook.Workbook.Names["k8s_cluster_name"].Value
                 'vmClass'                       = $pnpWorkbook.Workbook.Names["k8s_vm_class"].Value
+                'kubectlPath'                   = "C:\Kubectl\bin"
             }
             Close-ExcelPackage $pnpWorkbook -NoSave -ErrorAction SilentlyContinue
             $jsonObject | ConvertTo-Json -Depth 12 | Out-File -Encoding UTF8 -FilePath $jsonFile
@@ -60193,12 +60194,14 @@ Function Start-DriMenu {
                 }
                 5 {
                     if (!$headlessPassed) { Clear-Host }; Write-Host `n " $submenuTitle : $menuItem05" -Foregroundcolor Cyan; Write-Host ''
-                    Invoke-DriDeployment -jsonFile ($jsonPath + $jsonSpecFile) -certificates $certificatePath -binaries $binaryPath -kubectlPath "C:\Kubectl\bin\"
+                    $jsonData = (Get-Content -Path ($jsonPath + $jsonSpecFile)) | ConvertFrom-Json
+                    Invoke-DriDeployment -jsonFile ($jsonPath + $jsonSpecFile) -certificates $certificatePath -binaries $binaryPath -kubectlPath $jsonData.kubectlPath
                     waitKey
                 }
                 6 {
                     if (!$headlessPassed) { Clear-Host }; Write-Host `n " $submenuTitle : $menuItem06" -Foregroundcolor Cyan; Write-Host ''
-                    Invoke-UndoDriDeployment -jsonFile ($jsonPath + $jsonSpecFile) -binaries $binaryPath -kubectlPath "C:\Kubectl\bin\"
+                    $jsonData = (Get-Content -Path ($jsonPath + $jsonSpecFile)) | ConvertFrom-Json
+                    Invoke-UndoDriDeployment -jsonFile ($jsonPath + $jsonSpecFile) -binaries $binaryPath -kubectlPath $jsonData.kubectlPath
                     waitKey
                 }
                 B {


### PR DESCRIPTION
### Summary

- Enhanced `Export-DriJsonSpec` cmdlet to define the path to the Kubectl utility.
- Enhanced `Start-DriMenu` cmdlet to use the new JSON value for the path to the Kubectl utility.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

Closes #705 

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
