### PR TITLE
feat: pdr prerequisite check for nsx federation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Added `Set-NsxtTransportNode` cmdlet to apply additional configuration to a transport node.
 - Added `Remove-NsxtGlobalManagerStandby` cmdlet to delete the standby mode configuration from the NSX Global Manager.
 - Added `Undo-NsxtGlobalManagerStandby` cmdlet to remove the standby mode configuration from the NSX Global Manager.
+- Added `Test-PrereqNsxFederation` cmdlet to verify that NSX Federation for a Workload Domain is present.
 - Enhanced `Test-VrslcmPrerequisite` cmdlet to ensure all associated DNS entries are resolvable for both forward and reverse lookups.
 - Enhanced `Test-GlobalWsaPrerequisite` cmdlet to ensure all associated DNS entries are resolvable for both forward and reverse lookups.
 - Enhanced `Test-IlaPrerequisite` cmdlet to ensure all associated DNS entries are resolvable for both forward and reverse lookups.
@@ -55,6 +56,7 @@
 - Enhanced `Test-HrmPrerequisite` cmdlet to ensure all associated DNS entries are resolvable for both forward and reverse lookups.
 - Enhanced `Test-CbrPrerequisite` cmdlet to ensure all associated DNS entries are resolvable for both forward and reverse lookups.
 - Enhanced `Test-CcmPrerequisite` cmdlet to ensure all associated DNS entries are resolvable for both forward and reverse lookups.
+- Enhanced `Test-PdrPrerequisite` cmdlet to verify that NSX Federation is configured in the environment.
 - Removed Alias `Request-NsxToken` from `Request-NsxtToken` cmdlet.
 
 ## v2.11.1

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -11,7 +11,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.12.0.1015'
+    ModuleVersion = '2.12.0.1017'
 
     # ID used to uniquely identify this module
     GUID              = 'a6dfed7b-65d2-4da2-bdcc-7f3d3df9b75d'

--- a/docs/documentation/functions/nsx/Get-NsxtGlobalManagerConfig.md
+++ b/docs/documentation/functions/nsx/Get-NsxtGlobalManagerConfig.md
@@ -7,10 +7,10 @@ Retrieve the NSX Global Manager configuration.
 ## Syntax
 
 ```powershell
-Get-NsxtGlobalManagerConfig
+Get-NsxtGlobalManagerConfig [-localManager] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Get-NsxtGlobalManagerConfig` cmdlet retrieves the NSX Global Manager configuration.
 
@@ -23,3 +23,33 @@ Get-NsxtGlobalManagerConfig
 ```
 
 This example retrieves the NSX Global Manager configuration.
+
+### Example 2
+
+```powershell
+Get-NsxtGlobalManagerConfig -localManager
+```
+
+This example retrieves the NSX Global Manager configuration from the NSX Local Manager.
+
+## PARAMETERS
+
+### -localManager
+
+Parameter to retrieve the NSX Global Manager configuration from an NSX Local Manager.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Common Parameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).


### PR DESCRIPTION
### Summary

- Enhanced `Get-NsxtGlobalManagerConfig` cmdlet to retrieve global manager config from the local manager.
- Updated `Get-NsxtGlobalManagerConfig` documentation.
- Fixed `Test-PdrPrerequisite` cmdlet where DNS Servers were not extracted correctly.
- Enhanced `Test-PdrPrerequisite` cmdlet to verify that NSX Federation is configured in the environment.
- 
### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] Bugfix
- [x] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

Closes #708 

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
